### PR TITLE
feat: add svgAsVector option to preserve SVG elements as vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## [1.1.4] - 2026-01-19
 
 ### Added
+
 - **Tailwind CSS v4 Support**: Added robust color parsing for modern CSS color formats (e.g., `oklch`, `lab`, `display-p3`) used by Tailwind v4. The library now uses canvas-based normalization to support any valid CSS color.
-- **Text Gradient Fallback**: Text with CSS gradients (e.g., `background-clip: text`) now gracefully falls back to the *first color* of the gradient string instead of rendering as invisible or black.
+- **Text Gradient Fallback**: Text with CSS gradients (e.g., `background-clip: text`) now gracefully falls back to the _first color_ of the gradient string instead of rendering as invisible or black.
 - **List Marker Customization**: Support for `::marker` pseudo-element styles. Custom bullet colors and font sizes are now preserved in the generated PowerPoint.
 
 ### Fixed
+
 - **Text Alignment**: Fixed an issue where text containers were slightly shorter than browser rendering, causing overlap with subsequent elements. Added a precision buffer to account for font metric differences.
 - **Line Breaks**: Fixed an issue where `<br>` tags with surrounding whitespace caused double line breaks in the output.
 - **Missing Elements (Cone Fix)**: Fixed a bug where empty elements with solid backgrounds and partial border radii (e.g., decorative shapes) were skipped during rasterization. We now generate a high-fidelity Vector SVG for these shapes.
@@ -17,17 +20,20 @@ All notable changes to this project will be documented in this file.
 ## [1.1.3] - 2026-01-12
 
 ### Added
+
 - **Table Supprt**: Added support for table elements like `<table>`, `<th>` `<td>`, `<tr>` with basic css formatting.
 
 ## [1.1.2] - 2026-01-08
 
 ### Added
+
 - **Canvas Support**: Added support for `<canvas>` elements. Libraries like **ECharts** and **Chart.js** now render correctly as images instead of blank spaces.
 - **Backend Upload Support**: Added `skipDownload` option to `exportToPptx`. The function now returns a `Promise<Blob>`, allowing developers to upload the generated file to a server instead of triggering a browser download.
 - **List Configuration**: Added `listConfig` option to manually override bullet colors and spacing (before/after) globally.
 - **Icon Support in Lists**: Added logic to capture pseudo-element content (`::before`), ensuring icons (e.g., FontAwesome) inside list items are rendered correctly.
 
 ### Fixed
+
 - **Native Lists**: HTML `<ul>` and `<ol>` lists are now rendered as a single native PowerPoint text box with real bullets, rather than disconnected text shapes.
 - **Line Height Calculation**: Fixed an issue where pixel-based CSS `line-height` was interpreted as a multiplier in PowerPoint, causing text to overlap or crush.
 - **Paragraph Spacing**: CSS `margin-top` and `margin-bottom` are now correctly converted to PowerPoint points (`paraSpaceBefore` / `paraSpaceAfter`).

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,12 @@ Most HTML-to-PPTX libraries fail when faced with modern web design. They break o
 
 **dom-to-pptx** is different. It is a **Coordinate Scraper & Style Engine** that traverses your DOM, calculates the exact computed styles of every element (Flexbox/Grid positions, complex gradients, shadows), and mathematically maps them to native PowerPoint shapes and text boxes. The result is a fully editable, vector-sharp presentation that looks exactly like your web view.
 
-### 🛠️ Updates in v1.1.4
+### 🛠️ Updates in v1.1.5
+
+- **SVG Vector Export:** New `svgAsVector` option keeps SVG elements as vectors instead of rasterizing them. This enables "Convert to Shape" in PowerPoint for editable charts and graphics.
+
+### Updates in v1.1.4
+
 - **Tailwind CSS v4 Support** (oklch colors)
 - **Text Gradient Fallback**
 - **List Customization & Layout fixes**
@@ -96,7 +101,22 @@ document.getElementById('export-btn').addEventListener('click', async () => {
 });
 ```
 
-### 4. Browser Usage (Script Tags)
+### 4. SVG Vector Export (Editable Charts)
+
+If your HTML contains SVG elements (like charts), you can keep them as vectors for editing in PowerPoint:
+
+```javascript
+import { exportToPptx } from 'dom-to-pptx';
+
+await exportToPptx('#slide-with-charts', {
+  fileName: 'editable-charts.pptx',
+  svgAsVector: true, // SVGs remain as vectors, not rasterized
+});
+```
+
+In PowerPoint, right-click the SVG image and select **"Convert to Shape"** (or **Group > Ungroup**) to make it fully editable.
+
+### 5. Browser Usage (Script Tags)
 
 You can use `dom-to-pptx` directly via CDN. The bundle includes all dependencies.
 
@@ -271,15 +291,17 @@ Returns: `Promise<Blob>` - Resolves with the generated PPTX file data (Blob).
 
 **Options Object:**
 
-| Key              | Type      | Default         | Description                                                                                              |
-| :--------------- | :-------- | :-------------- | :------------------------------------------------------------------------------------------------------- |
-| `fileName`       | `string`  | `"export.pptx"` | The name of the downloaded file.                                                                         |
-| `autoEmbedFonts` | `boolean` | `true`          | Automatically detect and embed used fonts.                                                               |
-| `fonts`          | `Array`   | `[]`            | Manual array of font objects: `{ name, url }`.                                                           |
-| `skipDownload`   | `boolean` | `false`         | If `true`, the file is not downloaded automatically. Use the returned `Blob` for custom handling (upload). |
+| Key              | Type      | Default         | Description                                                                                                   |
+| :--------------- | :-------- | :-------------- | :------------------------------------------------------------------------------------------------------------ |
+| `fileName`       | `string`  | `"export.pptx"` | The name of the downloaded file.                                                                              |
+| `autoEmbedFonts` | `boolean` | `true`          | Automatically detect and embed used fonts.                                                                    |
+| `fonts`          | `Array`   | `[]`            | Manual array of font objects: `{ name, url }`.                                                                |
+| `skipDownload`   | `boolean` | `false`         | If `true`, the file is not downloaded automatically. Use the returned `Blob` for custom handling (upload).    |
+| `svgAsVector`    | `boolean` | `false`         | If `true`, keeps SVG elements as vectors (not rasterized). Enables "Convert to Shape" in PowerPoint.          |
 | `listConfig`     | `object`  | `undefined`     | Global overrides for list styles. Structure: `{ color: string, spacing: { before: number, after: number } }`. |
 
 **List Configuration Example:**
+
 ```javascript
 listConfig: {
   spacing: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-to-pptx",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A client-side library that converts any HTML element into a fully editable PowerPoint slide. **dom-to-pptx** transforms DOM structures into pixel-accurate `.pptx` content, preserving gradients, shadows, rounded images, and responsive layouts. It translates CSS Flexbox/Grid, linear-gradients, box-shadows, and typography into native PowerPoint shapes, enabling precise, design-faithful slide generation directly from the browser.",
   "main": "dist/dom-to-pptx.cjs",
   "module": "dist/dom-to-pptx.mjs",
@@ -13,7 +13,8 @@
     }
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "build": "npx rollup -c",
     "lint": "eslint .",
     "format": "prettier --write ."
@@ -66,11 +67,13 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "events": "^3.3.0",
+    "jsdom": "^28.0.0",
     "prettier": "^3.7.3",
     "process": "^0.11.10",
     "rollup-plugin-polyfill-node": "^0.10.1",
     "stream-browserify": "^3.0.0",
-    "util": "^0.12.5"
+    "util": "^0.12.5",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "fonteditor-core": "^2.6.3",

--- a/test/svg.test.js
+++ b/test/svg.test.js
@@ -1,0 +1,109 @@
+/* eslint-env node */
+/* global global */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// Set up DOM environment
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.XMLSerializer = dom.window.XMLSerializer;
+
+// Mock getComputedStyle
+global.window.getComputedStyle = (element) => ({
+  fill: element.getAttribute('fill') || 'none',
+  stroke: element.getAttribute('stroke') || 'none',
+  'stroke-width': '1',
+  'stroke-linecap': 'butt',
+  'stroke-linejoin': 'miter',
+  opacity: '1',
+  'font-family': 'Arial',
+  'font-size': '12px',
+  'font-weight': 'normal',
+});
+
+import { svgToPng, svgToSvg } from '../src/utils.js';
+
+describe('SVG conversion utilities', () => {
+  let testSvg;
+
+  beforeEach(() => {
+    // Create a simple SVG element for testing
+    testSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    testSvg.setAttribute('width', '100');
+    testSvg.setAttribute('height', '100');
+    testSvg.setAttribute('viewBox', '0 0 100 100');
+
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('x', '10');
+    rect.setAttribute('y', '10');
+    rect.setAttribute('width', '80');
+    rect.setAttribute('height', '80');
+    rect.setAttribute('fill', '#ff0000');
+    testSvg.appendChild(rect);
+
+    document.body.appendChild(testSvg);
+
+    // Mock getBoundingClientRect
+    testSvg.getBoundingClientRect = () => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 100,
+    });
+  });
+
+  describe('svgToSvg', () => {
+    it('should return an SVG data URL', async () => {
+      const result = await svgToSvg(testSvg);
+
+      expect(result).toBeTruthy();
+      expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+    });
+
+    it('should preserve SVG structure in the output', async () => {
+      const result = await svgToSvg(testSvg);
+
+      // Decode base64 to check content
+      const base64Data = result.replace('data:image/svg+xml;base64,', '');
+      const svgContent = atob(base64Data);
+
+      expect(svgContent).toContain('<svg');
+      expect(svgContent).toContain('xmlns="http://www.w3.org/2000/svg"');
+      expect(svgContent).toContain('<rect');
+    });
+
+    it('should set width and height attributes', async () => {
+      const result = await svgToSvg(testSvg);
+
+      const base64Data = result.replace('data:image/svg+xml;base64,', '');
+      const svgContent = atob(base64Data);
+
+      expect(svgContent).toContain('width="100"');
+      expect(svgContent).toContain('height="100"');
+    });
+  });
+
+  describe('svgToPng', () => {
+    it('should be a function', () => {
+      expect(typeof svgToPng).toBe('function');
+    });
+
+    // Note: Full PNG conversion tests require canvas which isn't available in jsdom
+    // These would need a browser environment or canvas polyfill
+  });
+});
+
+describe('svgAsVector option', () => {
+  it('should be documented in the export function JSDoc', async () => {
+    // This is a documentation check - the option should exist
+    const indexSource = await import('fs').then((fs) =>
+      fs.promises.readFile('./src/index.js', 'utf-8')
+    );
+
+    expect(indexSource).toContain('svgAsVector');
+    expect(indexSource).toContain('If true, keeps SVG as vector');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
This library was better than anything else I could find for my needs of creating beautiful slides with modern CSS. We have a data rich application and I found myself needing an option to export SVG based graphs as potentially editable vectors, so this PR adds a new `svgAsVector` option that keeps SVG elements as vector data URLs instead of rasterizing them to PNG. This enables "Convert to Shape" functionality in PowerPoint, allowing users to edit charts and graphics.

Changes:
- Add svgToSvg() function in utils.js that serializes SVG with inlined styles to a base64 SVG data URL
- Add svgAsVector option to exportToPptx() that routes SVG processing through either svgToSvg (vector) or svgToPng (raster)
- Extract inlineSvgStyles() helper for code reuse between both functions
- Add vitest test suite with basic coverage for new SVG functionality
- Update README with documentation and usage example
- Bump version to 1.1.5

Note: Run `pnpm install` to update lockfile with new devDependencies (vitest, jsdom).