### PR TITLE
docs: fix image examples code fence

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -124,6 +124,7 @@ If using `<style>` tags, ensure styles are applied correctly during export:
 
 Images must use **complete HTTPS URLs** or **data URLs**, and the server must support CORS:
 
+```html
 <!-- ✅ Correct -->
 <img src="https://images.unsplash.com/photo-xxx?w=400" />
 


### PR DESCRIPTION
- What: Fix the markdown fencing so “Image Handling” HTML examples render as a code block.
- Why: There was a closing fence without an opening fence, which breaks formatting.
- Scope: Docs only; no runtime changes.

i.e from : 
<img width="1369" height="425" alt="image" src="https://github.com/user-attachments/assets/7d7b9414-af7a-4036-85b3-47dc1b48bb21" />
to:
<img width="1372" height="449" alt="image" src="https://github.com/user-attachments/assets/1fdbc786-08aa-48cd-be56-b057e12adfe2" />



~ SGcpu