### PR TITLE
fix: prevent 1px text wrapping due to width/font-size rounding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -557,8 +557,12 @@ function prepareRenderItem(
   const elementOpacity = parseFloat(style.opacity);
   const safeOpacity = isNaN(elementOpacity) ? 1 : elementOpacity;
 
-  const widthPx = node.offsetWidth || rect.width;
-  const heightPx = node.offsetHeight || rect.height;
+  // Prefer the sub-pixel rect size to avoid 1px text-wrap artifacts caused by
+  // offsetWidth/offsetHeight being integer-rounded. When the element is rotated
+  // we must fall back to offset* because rect.* describes the rotated bounding box.
+  const widthPx = rotation === 0 ? rect.width || node.offsetWidth : node.offsetWidth || rect.width;
+  const heightPx =
+    rotation === 0 ? rect.height || node.offsetHeight : node.offsetHeight || rect.height;
   const unrotatedW = widthPx * PX_TO_INCH * config.scale;
   const unrotatedH = heightPx * PX_TO_INCH * config.scale;
   const centerX = rect.left + rect.width / 2;
@@ -1176,8 +1180,9 @@ function prepareRenderItem(
     }
 
     if (textPayload) {
+      const fs0 = textPayload.text[0]?.options?.fontSize;
       textPayload.text[0].options.fontSize =
-        Number(textPayload.text[0]?.options?.fontSize?.toFixed(1)) || 12;
+        typeof fs0 === 'number' ? Math.floor(fs0 * 10) / 10 : 12;
       items.push({
         type: 'text',
         zIndex: zIndex + 1,
@@ -1290,8 +1295,9 @@ function prepareRenderItem(
       }
 
       if (textPayload) {
+        const fs0 = textPayload.text[0]?.options?.fontSize;
         textPayload.text[0].options.fontSize =
-          Number(textPayload.text[0]?.options?.fontSize?.toFixed(1)) || 12;
+          typeof fs0 === 'number' ? Math.floor(fs0 * 10) / 10 : 12;
         const textOptions = {
           shape: shapeType,
           ...shapeOpts,

--- a/src/utils.js
+++ b/src/utils.js
@@ -475,7 +475,7 @@ export function getTextStyle(style, scale) {
   return {
     color: colorObj.hex || '000000',
     fontFace: style.fontFamily.split(',')[0].replace(/['"]/g, ''),
-    fontSize: Number((fontSizePx * 0.75 * scale).toFixed(1)),
+    fontSize: Math.floor(fontSizePx * 0.75 * scale * 10) / 10,
     bold: parseInt(style.fontWeight) >= 600,
     italic: style.fontStyle === 'italic',
     underline: style.textDecoration.includes('underline'),


### PR DESCRIPTION
Two related rounding issues caused PPTX text frames to be slightly narrower than the browser layout, occasionally pushing the last character onto a new line.

1. Element width was taken from offsetWidth/offsetHeight, which the browser rounds to integers. When the actual layout was e.g. 100.4px, the exported frame was 100/96 in (~1px short) so the same string at the same font no longer fit.
2. Font size used Number((px * 0.75 * scale).toFixed(1)), which rounds to nearest. A computed 11.95pt becomes 12.0pt in PPT, again widening the rendered text relative to the browser and triggering wrap.

Fix:
- Use rect.width/rect.height (sub-pixel) for unrotated elements; keep offsetWidth/Height for rotated elements because rect.* describes the rotated bounding box.
- Floor font size to 0.1pt so the exported size is never larger than the browser's, both in getTextStyle and in the two post-processing sites in index.js.