### PR TITLE
fix: invalid build devDependency name; honor CSS white-space (nowrap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^3.7.3",
     "process": "^0.11.10",
     "rollup": "^4.18.0",
-    "rollup-plugin-polyfil++++++++l-node": "^0.10.1",
+    "rollup-plugin-polyfill-node": "^0.10.1",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "vitest": "^4.0.18"

--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,18 @@ function prepareRenderItem(
               ),
             },
           ],
-          options: { x, y, w: unrotatedW, h: unrotatedH, margin: 0, autoFit: true },
+          // Honor CSS white-space: a `nowrap`/`pre` element must not re-wrap in
+          // the exported slide (otherwise a single line measured in the browser
+          // can wrap in PowerPoint/LibreOffice due to font-metric differences).
+          options: {
+            x,
+            y,
+            w: unrotatedW,
+            h: unrotatedH,
+            margin: 0,
+            autoFit: true,
+            wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
+          },
         },
       ],
       stopRecursion: false,
@@ -835,7 +846,7 @@ function prepareRenderItem(
           valign: 'top',
           margin: 0,
           autoFit: true,
-          wrap: true,
+          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
           vert: writingModeVert,
         },
       });
@@ -1210,7 +1221,7 @@ function prepareRenderItem(
           inset: textPayload.inset,
           rotate: rotation,
           margin: 0,
-          wrap: true,
+          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
           autoFit: true,
           vert: writingModeVert,
         },
@@ -1320,7 +1331,7 @@ function prepareRenderItem(
           valign: textPayload.valign,
           inset: textPayload.inset,
           margin: 0,
-          wrap: true,
+          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
           autoFit: true,
           vert: writingModeVert,
         };


### PR DESCRIPTION
Two small, independent fixes found while integrating `dom-to-pptx` into a Marp → PPTX pipeline.

## 1. Build fix: invalid `devDependency` name

`package.json` listed `"rollup-plugin-polyfil++++++++l-node"`, which is not a valid npm package name, so `npm install` fails outright — blocking builds and any contribution:

```
npm error Invalid package name "rollup-plugin-polyfil++++++++l-node" ... name can only contain URL-friendly characters.
```

Corrected to `rollup-plugin-polyfill-node`.

## 2. Honor CSS `white-space` (`nowrap`/`pre` → `wrap: false`)

Text boxes were always created with wrapping enabled, ignoring the element's CSS `white-space`. Because PowerPoint/LibreOffice font metrics differ slightly from Chrome's, a line measured as single-line in the browser can **re-wrap** in the exported PPTX — e.g. a heading breaks onto a second line (leaving a left accent bar stranded on line 1).

This maps `white-space: nowrap` (and `pre`) to PptxGenJS `wrap: false` across the text paths, so **authors control wrapping from CSS** (`white-space: nowrap` on a title) instead of the library relying on width fudge-factors. Default (`normal`) behavior is unchanged.

**Verified:** on a real Marp deck, a full-size title that wrapped to two lines now stays on one (`wrap="none"` in the slide XML); no regressions on other slides.
