### PR TITLE
fix(text): preserve line breaks for white-space pre/pre-wrap/pre-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`white-space: pre` / `pre-wrap` / `pre-line` now preserve line breaks**: text inside `<pre>` or elements with these `white-space` values previously had every newline, tab, and run of spaces collapsed to a single space (`collectTextParts`), so multi-line content (code blocks, ASCII art, formatted text) rendered as one line. Author newlines are now emitted as hard line breaks, and `pre`/`pre-wrap` preserve indentation/spaces (tabs become spaces, since PPTX text runs have no tab stops). `normal`/`nowrap` collapsing is unchanged.
+
 ## [1.1.10] - 2026-06-01
 
 ### Added

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -26,7 +26,8 @@ Note: The library measures computed layout from the browser (getBoundingClientRe
 - backdrop-filter: blur() (simulated via html2canvas snapshot)
 - transform: rotate() (extraction of rotation angle)
 - display, position, width, height, padding, margin
-- text-align, vertical-align, white-space, text-transform
+- text-align, vertical-align, text-transform
+- white-space (`normal`/`nowrap` collapse whitespace; `pre`/`pre-wrap`/`pre-line` preserve author line breaks, and `pre`/`pre-wrap` also preserve indentation/spaces)
 - font-family, font-size, font-weight, font-style, line-height
 
 ## Common utility/Tailwind-like classes (recognized by visual result)

--- a/src/__tests__/text-whitespace.test.js
+++ b/src/__tests__/text-whitespace.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { splitPreformattedText } from '../utils.js';
+
+const texts = (segs) => segs.map((s) => s.text);
+const breaks = (segs) => segs.map((s) => s.breakLine);
+
+describe('splitPreformattedText', () => {
+  it('preserves newlines as hard breaks (pre)', () => {
+    const segs = splitPreformattedText('line1\nline2\nline3', 'pre', { isLastChild: true });
+    expect(texts(segs)).toEqual(['line1', 'line2', 'line3']);
+    expect(breaks(segs)).toEqual([true, true, false]);
+  });
+
+  it('preserves leading indentation and inner spaces for pre / pre-wrap', () => {
+    expect(texts(splitPreformattedText('  a   b', 'pre', { isLastChild: true }))).toEqual([
+      '  a   b',
+    ]);
+    expect(texts(splitPreformattedText('  a   b', 'pre-wrap', { isLastChild: true }))).toEqual([
+      '  a   b',
+    ]);
+  });
+
+  it('collapses runs of spaces/tabs but keeps newlines for pre-line', () => {
+    const segs = splitPreformattedText('a\t \tb\n  c', 'pre-line', { isLastChild: true });
+    expect(texts(segs)).toEqual(['a b', ' c']);
+    expect(breaks(segs)).toEqual([true, false]);
+  });
+
+  it('renders tabs as spaces for pre (no PPTX tab stops)', () => {
+    expect(texts(splitPreformattedText('\tx', 'pre', { isLastChild: true }))).toEqual(['    x']);
+  });
+
+  it('keeps internal blank lines', () => {
+    const segs = splitPreformattedText('a\n\nb', 'pre', { isLastChild: true });
+    expect(texts(segs)).toEqual(['a', '', 'b']);
+    expect(breaks(segs)).toEqual([true, true, false]);
+  });
+
+  it('ignores a single newline immediately after a <pre> start tag', () => {
+    const segs = splitPreformattedText('\nfirst\nsecond', 'pre', {
+      isFirstChild: true,
+      isPre: true,
+      isLastChild: true,
+    });
+    expect(texts(segs)).toEqual(['first', 'second']);
+  });
+
+  it('does not strip the leading newline when not the first child or not <pre>', () => {
+    const segs = splitPreformattedText('\nfirst', 'pre-wrap', {
+      isFirstChild: true,
+      isPre: false,
+      isLastChild: true,
+    });
+    expect(texts(segs)).toEqual(['', 'first']);
+  });
+
+  it('drops a single trailing newline terminator on the last text node', () => {
+    expect(texts(splitPreformattedText('a\n', 'pre', { isLastChild: true }))).toEqual(['a']);
+  });
+
+  it('keeps a trailing newline when the text node is not the last child', () => {
+    // e.g. <pre>line1\n<span>x</span></pre> — the break before the span must survive
+    const segs = splitPreformattedText('line1\n', 'pre', { isLastChild: false });
+    expect(texts(segs)).toEqual(['line1', '']);
+    expect(breaks(segs)).toEqual([true, false]);
+  });
+
+  it('normalizes CRLF to a single break', () => {
+    expect(texts(splitPreformattedText('a\r\nb', 'pre', { isLastChild: true }))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('applies text-transform per line', () => {
+    expect(
+      texts(
+        splitPreformattedText('aa\nbb', 'pre', { isLastChild: true, textTransform: 'uppercase' })
+      )
+    ).toEqual(['AA', 'BB']);
+  });
+
+  it('returns nothing for empty / terminator-only content', () => {
+    expect(splitPreformattedText('\n', 'pre', { isLastChild: true })).toEqual([]);
+    expect(splitPreformattedText('', 'pre', { isLastChild: true })).toEqual([]);
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1081,6 +1081,47 @@ export async function getAutoDetectedFonts(usedFamilies) {
   return foundFonts;
 }
 
+/**
+ * Split a text node's value into line segments for an element whose effective
+ * CSS `white-space` preserves author line breaks (`pre`, `pre-wrap`, `pre-line`).
+ *
+ * Returns `[{ text, breakLine }]` where `breakLine` marks a hard line break after
+ * that segment (PptxGenJS `breakLine`). Pure string logic — no DOM/canvas — so it
+ * is unit-testable in isolation.
+ *
+ * Rules (per CSS Text spec):
+ *  - `pre` / `pre-wrap`: keep newlines AND runs of spaces; tabs become spaces
+ *    (PPTX text runs have no tab stops).
+ *  - `pre-line`: keep newlines but collapse runs of spaces/tabs.
+ *  - A single newline right after a `<pre>` start tag is ignored (HTML parsing).
+ *  - A single trailing newline on the last text node is the line terminator and
+ *    is dropped, so `<pre>a\n</pre>` is one line, not one line + a blank one.
+ */
+export function splitPreformattedText(value, whiteSpace, options = {}) {
+  const {
+    isFirstChild = false,
+    isLastChild = false,
+    isPre = false,
+    textTransform = 'none',
+  } = options;
+
+  let raw = String(value).replace(/\r\n?/g, '\n');
+  if (isFirstChild && isPre && raw[0] === '\n') raw = raw.slice(1);
+  raw = whiteSpace === 'pre-line' ? raw.replace(/[ \t]+/g, ' ') : raw.replace(/\t/g, '    ');
+  if (isLastChild) raw = raw.replace(/\n$/, '');
+  if (!raw.length) return [];
+
+  const transform = (s) => {
+    if (textTransform === 'uppercase') return s.toUpperCase();
+    if (textTransform === 'lowercase') return s.toLowerCase();
+    if (textTransform === 'capitalize') return s.replace(/\b\w/g, (c) => c.toUpperCase());
+    return s;
+  };
+
+  const lines = raw.split('\n');
+  return lines.map((line, i) => ({ text: transform(line), breakLine: i < lines.length - 1 }));
+}
+
 export function collectTextParts(
   node,
   parentStyle,
@@ -1135,7 +1176,39 @@ export function collectTextParts(
 
   node.childNodes.forEach((child, index) => {
     if (child.nodeType === 3) {
-      // Text
+      // Honor CSS white-space: pre / pre-wrap / pre-line preserve author line
+      // breaks (and, except pre-line, runs of spaces). Without this, every newline
+      // and indent inside a <pre> / white-space:pre(-wrap) block is collapsed to a
+      // single space and multi-line content renders as one run.
+      const wsStyle = node.nodeType === 1 ? window.getComputedStyle(node) : parentStyle;
+      const whiteSpace = wsStyle.whiteSpace || 'normal';
+      if (whiteSpace === 'pre' || whiteSpace === 'pre-wrap' || whiteSpace === 'pre-line') {
+        const segs = splitPreformattedText(child.nodeValue, whiteSpace, {
+          isFirstChild: index === 0,
+          isLastChild: index === node.childNodes.length - 1,
+          isPre: node.nodeType === 1 && node.tagName === 'PRE',
+          textTransform: wsStyle.textTransform,
+        });
+        if (segs.length) {
+          const baseOpts = getTextStyle(wsStyle, scale, !isRoot, inheritedOpacity);
+          if (hyperlink) baseOpts.hyperlink = hyperlink;
+          if (baseOpts.charSpacing !== undefined && baseOpts.fontFace) {
+            baseOpts.fontFace = `${baseOpts.fontFace}__spc_${Math.round(baseOpts.charSpacing * 100)}`;
+          }
+          // Naked text node: don't paint the parent background as a text highlight.
+          delete baseOpts.highlight;
+          segs.forEach((seg) => {
+            parts.push({
+              text: seg.text,
+              options: seg.breakLine ? { ...baseOpts, breakLine: true } : { ...baseOpts },
+            });
+          });
+        }
+        trimNextLeading = false;
+        return;
+      }
+
+      // Text (white-space: normal / nowrap — collapse runs of whitespace)
       let val = child.nodeValue.replace(/[\n\r\t]+/g, ' ').replace(/\s{2,}/g, ' ');
 
       if (index === 0) val = val.trimStart();


### PR DESCRIPTION
## Problem
`collectTextParts` collapsed every newline, tab and run of spaces to a single space regardless of the element's `white-space`. So `<pre>` and `white-space: pre/pre-wrap` content (code blocks, ASCII art, formatted text) exported as a single line.

## Fix
Detect the effective `white-space` on the text node's container:
- `pre` / `pre-wrap` / `pre-line`: author newlines become hard line breaks (PptxGenJS `breakLine`).
- `pre` / `pre-wrap`: indentation and inner spaces are preserved (tabs become spaces, since PPTX text runs have no tab stops).
- `pre-line`: spaces collapse but newlines are kept.
- `normal` / `nowrap`: unchanged.

Also honors the HTML rule that a single newline immediately after `<pre>` is ignored, and drops a single trailing terminator newline so `<pre>a\n</pre>` is one line, not one line plus a blank one.

## Tests
The pure string logic is extracted into an exported `splitPreformattedText()` with 12 unit tests (leading-newline rule, trailing terminator, blank lines, CRLF, tab handling, text-transform, pre-line space collapsing). `pnpm test` passes, `pnpm lint` is clean, `pnpm build` succeeds. Verified end-to-end: a `<pre>` block exports as separate paragraphs with indentation intact, while a normal paragraph containing a source newline still collapses to one line.
