### PR TITLE
fix(animations): use classList instead of className.split() for SVG compatibility

### DIFF
--- a/src/__tests__/animations.test.js
+++ b/src/__tests__/animations.test.js
@@ -115,6 +115,31 @@ describe('css-parser - parseAnimation', () => {
     const parsed = parseAnimation(node, style);
     expect(parsed.start).toBe('after');
   });
+
+  it('does not throw on SVG elements whose className is an SVGAnimatedString', () => {
+    // Regression: parseAnimation used to call node.className.split(/\s+/),
+    // which throws on SVG elements because SVGElement.className is an
+    // SVGAnimatedString, not a string. Any inline <svg> with a class
+    // attribute would abort the entire PPTX export. classList is safe on
+    // both HTML and SVG elements.
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'fade-in some-utility');
+    // dataset is not defined on SVGElement in every DOM implementation, so
+    // add an empty one to keep the parser happy — the point of the test is
+    // just that we do not crash on the className access.
+    if (!svg.dataset) svg.dataset = {};
+    const style = {
+      animationName: 'fade-in',
+      animationDuration: '0.5s',
+      animationDelay: '0s',
+      getPropertyValue: () => '',
+    };
+
+    expect(() => parseAnimation(svg, style)).not.toThrow();
+    const parsed = parseAnimation(svg, style);
+    expect(parsed).not.toBeNull();
+    expect(parsed.name).toBe('fade-in');
+  });
 });
 
 describe('xml-templates - getPreset', () => {

--- a/src/animations/css-parser.js
+++ b/src/animations/css-parser.js
@@ -118,8 +118,11 @@ export function parseAnimation(node, style) {
   }
 
   if (!name || name === 'none' || name === '') {
-    // Last resort: scan className list for a known animation name
-    const classNames = node.className ? node.className.split(/\s+/) : [];
+    // Last resort: scan className list for a known animation name.
+    // Use classList rather than className.split() because SVG elements
+    // expose className as an SVGAnimatedString, not a string; calling
+    // .split() on it throws and aborts the whole PPTX export.
+    const classNames = Array.from(node.classList || []);
     for (const cls of classNames) {
       if (ENTRANCE_NAMES.has(cls) || EXIT_NAMES.has(cls)) {
         name = cls;
@@ -146,7 +149,9 @@ export function parseAnimation(node, style) {
   }
 
   // ── 3. Resolve duration ──────────────────────────────────────────────────
-  const classList = node.className ? node.className.split(/\s+/) : [];
+  // classList is safe on both HTML and SVG elements; className.split() is not
+  // (SVG className is an SVGAnimatedString, not a string).
+  const classList = Array.from(node.classList || []);
   const { duration: utilDuration, delay: utilDelay } = parseUtilityClass(classList);
 
   let durationStr =


### PR DESCRIPTION
## Summary

`parseAnimation` walks every element in the DOM tree during export. When
the walker reaches an inline SVG element, `node.className` is an
`SVGAnimatedString` rather than a string, so calling `.split(/\s+/)` on it
throws a `TypeError` and aborts the entire PPTX export.

`classList` is a `DOMTokenList` on both `HTMLElement` and `SVGElement`, so
`Array.from(node.classList || [])` works uniformly across element types.

## Reproduction

Any deck that contains an inline `<svg>` with a `class` attribute — for
example Font Awesome icons rendered as SVG, or hand-authored SVG
illustrations used as slide decorations — crashes with:

```
TypeError: node.className.split is not a function
    at parseAnimation (src/animations/css-parser.js:122)
```

## Fix

Two sites in `src/animations/css-parser.js`:

- Line 122 (animation-name fallback scan)
- Line 149 (utility-class duration/delay parsing)

Both switched from `node.className.split(/\s+/)` to
`Array.from(node.classList || [])`.

## Tests

Adds a jsdom-based regression test in `src/__tests__/animations.test.js`
that constructs a real SVG element with a class attribute and asserts
`parseAnimation` neither throws nor returns null. On master (without the
fix), this test fails with the exact production `TypeError` above.

All 30 animation tests pass on this branch (29 pre-existing + 1 new).

## Notes

The existing test suite already provides `classList` arrays on its mock
nodes for HTML elements, so the change is a no-op for those tests.
