### PR TITLE
fix(fonts): embed each @font-face variant into its own PowerPoint slot

### DIFF
--- a/src/__tests__/font-embedder.test.js
+++ b/src/__tests__/font-embedder.test.js
@@ -1,0 +1,118 @@
+// src/__tests__/font-embedder.test.js
+//
+// Tests for PPTXEmbedFonts.updatePresentationXML — specifically that
+// multiple @font-face variants for the same family (Regular, Bold, etc.)
+// each get their own slot in <p:embeddedFontLst>. Before the fix, the
+// method walked this.fonts and short-circuited on the first entry that
+// matched a given typeface, so a Bold font added after a Regular one
+// under the same family name was silently dropped and PowerPoint had to
+// synthesise fake-bold from Regular glyphs.
+//
+// We push directly to embedder.fonts here rather than going through
+// addFont() so we do not need real font buffers (addFont() runs the data
+// through fontToEot / opentype.js). The XML emit is the code path with
+// the bug, and it is fully exercised without any font conversion.
+
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { PPTXEmbedFonts } from '../font-embedder.js';
+
+const P_NS = 'http://schemas.openxmlformats.org/presentationml/2006/main';
+
+function buildMinimalPresentationZip() {
+  const zip = new JSZip();
+  zip.file(
+    'ppt/presentation.xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="${P_NS}"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:defaultTextStyle/>
+</p:presentation>`
+  );
+  return zip;
+}
+
+async function embeddedFontLstFromZip(zip) {
+  const xml = await zip.file('ppt/presentation.xml').async('string');
+  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  return doc.getElementsByTagName('p:embeddedFontLst')[0] || null;
+}
+
+describe('PPTXEmbedFonts.updatePresentationXML', () => {
+  it('emits one <p:embeddedFont> per family with a child element per declared variant', async () => {
+    const zip = buildMinimalPresentationZip();
+    const embedder = new PPTXEmbedFonts();
+    await embedder.loadZip(zip);
+
+    // Two variants for the same family plus one variant for a second family.
+    embedder.fonts = [
+      { name: 'Inter', variant: 'regular', data: new Uint8Array(0), rid: 201314 },
+      { name: 'Inter', variant: 'bold', data: new Uint8Array(0), rid: 201315 },
+      { name: 'Merriweather', variant: 'italic', data: new Uint8Array(0), rid: 201316 },
+    ];
+
+    await embedder.updatePresentationXML();
+
+    const embeddedFontLst = await embeddedFontLstFromZip(zip);
+    expect(embeddedFontLst).not.toBeNull();
+
+    const embeddedFonts = Array.from(embeddedFontLst.getElementsByTagName('p:embeddedFont'));
+    expect(embeddedFonts).toHaveLength(2);
+
+    const inter = embeddedFonts.find(
+      (n) => n.getElementsByTagName('p:font')[0].getAttribute('typeface') === 'Inter'
+    );
+    expect(inter).toBeTruthy();
+    expect(inter.getElementsByTagName('p:regular')).toHaveLength(1);
+    expect(inter.getElementsByTagName('p:bold')).toHaveLength(1);
+    expect(inter.getElementsByTagName('p:italic')).toHaveLength(0);
+    expect(inter.getElementsByTagName('p:boldItalic')).toHaveLength(0);
+    expect(inter.getElementsByTagName('p:regular')[0].getAttribute('r:id')).toBe('rId201314');
+    expect(inter.getElementsByTagName('p:bold')[0].getAttribute('r:id')).toBe('rId201315');
+
+    const merri = embeddedFonts.find(
+      (n) => n.getElementsByTagName('p:font')[0].getAttribute('typeface') === 'Merriweather'
+    );
+    expect(merri).toBeTruthy();
+    expect(merri.getElementsByTagName('p:italic')).toHaveLength(1);
+    expect(merri.getElementsByTagName('p:regular')).toHaveLength(0);
+    expect(merri.getElementsByTagName('p:italic')[0].getAttribute('r:id')).toBe('rId201316');
+  });
+
+  it('defaults to the regular slot when a font has no variant field (backward compatible)', async () => {
+    const zip = buildMinimalPresentationZip();
+    const embedder = new PPTXEmbedFonts();
+    await embedder.loadZip(zip);
+
+    // Old-style entries with no variant should still land in <p:regular>.
+    embedder.fonts = [{ name: 'LegacyFont', data: new Uint8Array(0), rid: 201314 }];
+
+    await embedder.updatePresentationXML();
+
+    const embeddedFontLst = await embeddedFontLstFromZip(zip);
+    const embeddedFonts = Array.from(embeddedFontLst.getElementsByTagName('p:embeddedFont'));
+    expect(embeddedFonts).toHaveLength(1);
+    expect(embeddedFonts[0].getElementsByTagName('p:regular')).toHaveLength(1);
+    expect(embeddedFonts[0].getElementsByTagName('p:bold')).toHaveLength(0);
+  });
+
+  it('does not duplicate an existing <p:embeddedFont> entry on repeat calls', async () => {
+    const zip = buildMinimalPresentationZip();
+    const embedder = new PPTXEmbedFonts();
+    await embedder.loadZip(zip);
+
+    embedder.fonts = [
+      { name: 'Inter', variant: 'regular', data: new Uint8Array(0), rid: 201314 },
+      { name: 'Inter', variant: 'bold', data: new Uint8Array(0), rid: 201315 },
+    ];
+
+    await embedder.updatePresentationXML();
+    await embedder.updatePresentationXML();
+
+    const embeddedFontLst = await embeddedFontLstFromZip(zip);
+    const interBlocks = Array.from(embeddedFontLst.getElementsByTagName('p:embeddedFont')).filter(
+      (n) => n.getElementsByTagName('p:font')[0].getAttribute('typeface') === 'Inter'
+    );
+    expect(interBlocks).toHaveLength(1);
+  });
+});

--- a/src/font-embedder.js
+++ b/src/font-embedder.js
@@ -36,7 +36,7 @@ export class PPTXEmbedFonts {
     }
   }
 
-  async addFont(fontFace, source, typeOrWasmUrl, wasmUrl) {
+  async addFont(fontFace, source, typeOrWasmUrl, wasmUrl, variant) {
     // Convert to EOT/fntdata for PPTX compatibility
     let eotData;
     if (Array.isArray(source)) {
@@ -45,7 +45,10 @@ export class PPTXEmbedFonts {
       eotData = await fontToEot(typeOrWasmUrl, source, wasmUrl);
     }
     const rid = this.rId++;
-    this.fonts.push({ name: fontFace, data: eotData, rid });
+    // variant is one of: regular, bold, italic, boldItalic (PowerPoint's
+    // four embedded-font slots). Default to regular for callers that do
+    // not supply one, preserving the previous single-slot behaviour.
+    this.fonts.push({ name: fontFace, variant: variant || 'regular', data: eotData, rid });
   }
 
   async updateFiles() {
@@ -119,30 +122,45 @@ export class PPTXEmbedFonts {
       }
     }
 
-    // Add font references
+    // Group added fonts by typeface so we can emit one <p:embeddedFont>
+    // block per family with the right variant children. PowerPoint's
+    // embedded-font model supports four slots per family: regular, bold,
+    // italic, boldItalic. Emitting only <p:regular> when Bold was declared
+    // causes PowerPoint to fall back to synthesising bold from the Regular
+    // glyphs, which renders visibly differently from real Bold.
+    const byName = new Map();
     this.fonts.forEach((font) => {
-      // Check if already exists
-      const existing =
+      if (!byName.has(font.name)) byName.set(font.name, []);
+      byName.get(font.name).push(font);
+    });
+
+    const variantOrder = ['regular', 'bold', 'italic', 'boldItalic'];
+
+    byName.forEach((variants, name) => {
+      const alreadyDeclared =
         Array.from(embeddedFontLst.getElementsByTagNameNS(P_NS, 'font')).find(
-          (node) => node.getAttribute('typeface') === font.name
+          (node) => node.getAttribute('typeface') === name
         ) ||
         Array.from(embeddedFontLst.getElementsByTagName('p:font')).find(
-          (node) => node.getAttribute('typeface') === font.name
+          (node) => node.getAttribute('typeface') === name
         );
+      if (alreadyDeclared) return;
 
-      if (!existing) {
-        const embedFont = doc.createElementNS(P_NS, 'p:embeddedFont');
+      const embedFont = doc.createElementNS(P_NS, 'p:embeddedFont');
+      const fontNode = doc.createElementNS(P_NS, 'p:font');
+      fontNode.setAttribute('typeface', name);
+      embedFont.appendChild(fontNode);
 
-        const fontNode = doc.createElementNS(P_NS, 'p:font');
-        fontNode.setAttribute('typeface', font.name);
-        embedFont.appendChild(fontNode);
-
-        const regular = doc.createElementNS(P_NS, 'p:regular');
-        regular.setAttributeNS(R_NS, 'r:id', `rId${font.rid}`);
-        embedFont.appendChild(regular);
-
-        embeddedFontLst.appendChild(embedFont);
+      for (const variantName of variantOrder) {
+        const font = variants.find((v) => (v.variant || 'regular') === variantName);
+        if (font) {
+          const el = doc.createElementNS(P_NS, 'p:' + variantName);
+          el.setAttributeNS(R_NS, 'r:id', 'rId' + font.rid);
+          embedFont.appendChild(el);
+        }
       }
+
+      embeddedFontLst.appendChild(embedFont);
     });
 
     this.zip.file('ppt/presentation.xml', new XMLSerializer().serializeToString(doc));

--- a/src/index.js
+++ b/src/index.js
@@ -149,20 +149,42 @@ export async function exportToPptx(target, options = {}) {
   let rawFonts = options.fonts || [];
   let fontsToEmbed;
 
-  // Group by name
+  // Classify a CSS font-weight / font-style pair into one of the four slots
+  // that PowerPoint's embedded-font list supports: regular, bold, italic,
+  // boldItalic. Anything at weight >= 600 counts as bold; italic/oblique
+  // counts as italic.
+  const classifyVariant = (weight, style) => {
+    const wRaw = String(weight || '400').toLowerCase().trim();
+    let w = parseInt(wRaw, 10);
+    if (isNaN(w)) {
+      if (wRaw === 'bold' || wRaw === 'bolder') w = 700;
+      else if (wRaw === 'lighter') w = 300;
+      else w = 400;
+    }
+    const isBold = w >= 600;
+    const sRaw = String(style || 'normal').toLowerCase();
+    const isItalic = sRaw === 'italic' || sRaw === 'oblique';
+    if (isBold && isItalic) return 'boldItalic';
+    if (isBold) return 'bold';
+    if (isItalic) return 'italic';
+    return 'regular';
+  };
+
+  // Group by (name, variant) so each PowerPoint slot gets its own font.
   const uniqueFonts = new Map();
+  const addToGroup = (name, variant, url) => {
+    const key = name + '::' + variant;
+    if (!uniqueFonts.has(key)) {
+      uniqueFonts.set(key, { name, variant, urls: new Set() });
+    }
+    uniqueFonts.get(key).urls.add(url);
+  };
 
   for (const f of rawFonts) {
-    if (!uniqueFonts.has(f.name)) {
-      uniqueFonts.set(f.name, new Set());
-    }
-    if (f.url) {
-      uniqueFonts.get(f.name).add(f.url);
-    }
+    const variant = classifyVariant(f.weight, f.style);
+    if (f.url) addToGroup(f.name, variant, f.url);
     if (f.urls) {
-      for (const url of f.urls) {
-        uniqueFonts.get(f.name).add(url);
-      }
+      for (const url of f.urls) addToGroup(f.name, variant, url);
     }
   }
 
@@ -170,28 +192,27 @@ export async function exportToPptx(target, options = {}) {
     // A. Scan DOM for used font families
     const usedFamilies = getUsedFontFamilies(elements);
 
-    // B. Scan CSS for URLs matches
+    // B. Scan CSS for URLs matches (each carries weight+style now)
     const detectedFonts = await getAutoDetectedFonts(usedFamilies);
 
-    // C. Merge (collect all URLs for each font name)
+    // C. Merge, keyed by (name, variant) so Bold does not collapse into Regular
     for (const autoFont of detectedFonts) {
-      if (!uniqueFonts.has(autoFont.name)) {
-        uniqueFonts.set(autoFont.name, new Set());
-      }
-      uniqueFonts.get(autoFont.name).add(autoFont.url);
+      const variant = classifyVariant(autoFont.weight, autoFont.style);
+      addToGroup(autoFont.name, variant, autoFont.url);
     }
 
     if (detectedFonts.length > 0) {
       console.log(
         'Auto-detected fonts:',
-        detectedFonts.map((f) => f.name)
+        detectedFonts.map((f) => `${f.name} (${classifyVariant(f.weight, f.style)})`)
       );
     }
   }
 
-  fontsToEmbed = Array.from(uniqueFonts.entries()).map(([name, urlSet]) => ({
-    name,
-    urls: Array.from(urlSet),
+  fontsToEmbed = Array.from(uniqueFonts.values()).map((entry) => ({
+    name: entry.name,
+    variant: entry.variant,
+    urls: Array.from(entry.urls),
   }));
 
   if (fontsToEmbed.length > 0) {
@@ -234,7 +255,13 @@ export async function exportToPptx(target, options = {}) {
             })
           );
 
-          await embedder.addFont(fontCfg.name, subsets, options.woff2WasmUrl);
+          await embedder.addFont(
+            fontCfg.name,
+            subsets,
+            options.woff2WasmUrl,
+            undefined,
+            fontCfg.variant || 'regular'
+          );
         } catch (e) {
           console.warn(`Failed to embed font family: ${fontCfg.name}`, e);
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1066,7 +1066,14 @@ export async function getAutoDetectedFonts(usedFamilies) {
 
             if (url && !processedUrls.has(url)) {
               processedUrls.add(url);
-              foundFonts.push({ name: familyName, url: url });
+              // Preserve font-weight and font-style so downstream grouping can
+              // classify each @font-face declaration into one of PowerPoint's
+              // four embedded-font slots (regular / bold / italic / boldItalic).
+              // Without this, all variants for a family collapse into a single
+              // Regular embed and PowerPoint synthesises fake bold.
+              const weight = rule.style.getPropertyValue('font-weight').trim() || '400';
+              const fontStyle = (rule.style.getPropertyValue('font-style').trim() || 'normal').toLowerCase();
+              foundFonts.push({ name: familyName, url: url, weight: weight, style: fontStyle });
             }
           }
         }


### PR DESCRIPTION
## Summary

When a page declares multiple `@font-face` rules for the same family at
different weights or styles (e.g. Inter Regular + Inter Bold), auto-embed
currently collapses them into a single embedded font that is essentially
Regular, and writes a `<p:embeddedFont>` block containing only
`<p:regular>`. Any text with `<a:rPr b="1">` then falls through
PowerPoint's embedded-font lookup and PowerPoint synthesises bold from the
Regular glyphs. Result: bold and heavy weights render as fake-bold
Regular, which is visibly wrong for headline-weighted typography.

This PR carries `font-weight` and `font-style` through the pipeline as a
variant (`regular` | `bold` | `italic` | `boldItalic`) — the same four
slots PowerPoint's embedded-font model supports — and emits the correct
child element for each declared variant.

## Root cause

Three cooperating causes:

1. `getAutoDetectedFonts` (`src/utils.js`) returns `{ name, url }` per
   `@font-face` rule, discarding the rule's `font-weight` and
   `font-style`.
2. The font-grouping pass in `exportToPptx` (`src/index.js`) collects all
   URLs for a given family name into one `Set`, further stripping variant
   information.
3. `PPTXEmbedFonts.updatePresentationXML` (`src/font-embedder.js`) only
   emits `<p:regular>` regardless of what the source declared, and
   short-circuits on the first `<p:font typeface="...">` it sees so
   additional entries for the same family are silently dropped.

Result: any deck with multi-weight typography (which is most designed
decks) renders wrong in PowerPoint even when auto-embed is enabled.

## Fix (four touch points)

### 1. `src/utils.js` — capture weight and style

`getAutoDetectedFonts` now reads `font-weight` and `font-style` from each
`@font-face` rule and includes them on each returned entry.

### 2. `src/index.js` — key grouping by (name, variant)

A small `classifyVariant(weight, style)` helper maps CSS values into the
four PowerPoint slots (`regular`, `bold`, `italic`, `boldItalic`). The
`uniqueFonts` map is now keyed by `name::variant` instead of `name`, so
Bold does not collapse into Regular.

### 3. `src/font-embedder.js` — `addFont` accepts a `variant`

`addFont(fontFace, source, typeOrWasmUrl, wasmUrl, variant)` — the new
parameter is optional and defaults to `'regular'`, preserving existing
behaviour for any external caller. The variant is stored on each entry
in `this.fonts`.

### 4. `src/font-embedder.js` — `updatePresentationXML` groups by family

Instead of iterating `this.fonts` and short-circuiting on first match,
the method now groups by family name and emits one `<p:embeddedFont>`
block per family with a `<p:regular>` / `<p:bold>` / `<p:italic>` /
`<p:boldItalic>` child for each variant that was declared.

## Verification

Applied against a 25-slide deck with `@font-face` rules for Inter at
weights 400/500/700/900.

**Before the fix:**

```xml
<p:embeddedFontLst>
  <p:embeddedFont>
    <p:font typeface="Inter"/>
    <p:regular r:id="rId201314"/>       <!-- only Regular; Bold discarded -->
  </p:embeddedFont>
</p:embeddedFontLst>
```

**After the fix:**

```xml
<p:embeddedFontLst>
  <p:embeddedFont>
    <p:font typeface="Inter"/>
    <p:regular r:id="rId201314"/>       <!-- Inter Regular (merged with Medium) -->
    <p:bold r:id="rId201315"/>          <!-- Inter Bold (merged with Black) -->
  </p:embeddedFont>
</p:embeddedFontLst>
```

Bold text renders correctly in Microsoft PowerPoint instead of as
fake-bold Regular.

## Tests

Adds three tests in a new `src/__tests__/font-embedder.test.js`:

1. **Multi-variant emit** — pushes Regular + Bold entries for one family
   and Italic for a second family, asserts the resulting XML contains one
   `<p:embeddedFont>` per family with the correct variant children. Fails
   on master (only `<p:regular>` is emitted; Bold silently dropped), passes
   on this branch.
2. **Legacy compatibility** — fonts without a variant field still land in
   `<p:regular>`, preserving behaviour for external callers.
3. **Idempotency** — calling `updatePresentationXML` twice does not
   duplicate the `<p:embeddedFont>` blocks.

All 59 tests pass (56 pre-existing + 3 new; 1 pre-existing skipped).

## Known limitation

PowerPoint's embedded-font model only supports four variants per family
(`regular`, `bold`, `italic`, `boldItalic`). There is no slot for "Black"
(weight 900) or "Medium" (weight 500) as separate embedded fonts under
the same family name — weight 900 gets classified as `bold` (same slot as
weight 700). Full-fidelity weight 900 rendering requires the CSS to
declare it under a separate family name (e.g. `font-family: 'Inter Black'`
rather than `font-family: 'Inter'; font-weight: 900`), which is out of
scope for this patch.
