### PR TITLE
feat(exporter): enable --allow-file-access-from-files by default

### DIFF
--- a/src/__tests__/node-exporter.test.js
+++ b/src/__tests__/node-exporter.test.js
@@ -1,0 +1,40 @@
+// src/__tests__/node-exporter.test.js
+//
+// Tests for the Puppeteer launch-arg helper used by exportHtmlToPptx.
+//
+// Motivation: without --allow-file-access-from-files, Chromium blocks
+// fetch() from a file:// page to other file:// URLs — which is the
+// exact code path autoEmbedFonts uses to pull local .ttf files into an
+// embedded font blob. The failure is silent (fetch just rejects, the
+// per-font warn is easy to miss), so users end up with a fonts-less
+// PPTX that PowerPoint renders in a fallback system font. Enabling the
+// flag by default prevents that failure mode.
+
+import { describe, it, expect } from 'vitest';
+import { getLaunchArgs } from '../node-exporter.js';
+
+describe('getLaunchArgs', () => {
+  it('enables --allow-file-access-from-files for Chrome/Chromium/Edge', () => {
+    const args = getLaunchArgs('chrome');
+    expect(args).toContain('--allow-file-access-from-files');
+  });
+
+  it('keeps the existing --no-sandbox flags for Chrome-family browsers', () => {
+    const args = getLaunchArgs('chrome');
+    expect(args).toContain('--no-sandbox');
+    expect(args).toContain('--disable-setuid-sandbox');
+  });
+
+  it('returns an empty arg list for Firefox (WebDriver BiDi manages its own launch)', () => {
+    expect(getLaunchArgs('firefox')).toEqual([]);
+  });
+
+  it('is a pure function — repeated calls produce distinct arrays that can be safely mutated', () => {
+    const a = getLaunchArgs('chrome');
+    const b = getLaunchArgs('chrome');
+    expect(a).toEqual(b);
+    // Mutating one should not affect the other.
+    a.push('--custom');
+    expect(b).not.toContain('--custom');
+  });
+});

--- a/src/node-exporter.js
+++ b/src/node-exporter.js
@@ -3,6 +3,36 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * Compute the browser launch args for a given Puppeteer product.
+ *
+ * Chrome / Chromium / Edge get:
+ *   - `--no-sandbox` and `--disable-setuid-sandbox` because Puppeteer
+ *     runs the browser as an unprivileged user in most CI/server envs
+ *     where the setuid sandbox is unavailable.
+ *   - `--allow-file-access-from-files` so that XHR / fetch() from a
+ *     file:// page can reach other file:// URLs. Without this flag,
+ *     autoEmbedFonts silently fails whenever the caller's @font-face
+ *     rules point at local .ttf files (a common setup for offline deck
+ *     builds), and PowerPoint falls back to a system font on open. The
+ *     flag scopes only to file:// origins, so it does not weaken
+ *     security when exporting http(s):// pages.
+ *
+ * Firefox does not accept the Chrome flags and manages its own
+ * sandboxing, so we pass an empty array there.
+ *
+ * Exported so callers can override or extend the default set, and so
+ * the default is unit-testable without spinning up a browser.
+ *
+ * @param {'chrome'|'firefox'} product
+ * @returns {string[]}
+ */
+export function getLaunchArgs(product) {
+  if (product === 'firefox') return [];
+  return ['--no-sandbox', '--disable-setuid-sandbox', '--allow-file-access-from-files'];
+}
+
+
 // ─── Platform-aware browser search map ───────────────────────────────────────
 // Each entry is { name, product, paths[] }.
 // `product` is 'chrome' or 'firefox' — controls puppeteer launch args.
@@ -167,11 +197,7 @@ export async function exportHtmlToPptx(htmlSource, options = {}) {
   // Resolve browser — self-managing, no external setup required
   const { executablePath, product } = await ensureBrowser(puppeteer);
 
-  // Firefox uses WebDriver BiDi — different launch args than Chrome/Edge
-  const launchArgs =
-    product === 'firefox'
-      ? [] // Firefox manages sandboxing itself
-      : ['--no-sandbox', '--disable-setuid-sandbox'];
+  const launchArgs = getLaunchArgs(product);
 
   let browser;
   try {


### PR DESCRIPTION
## Summary

When `autoEmbedFonts` is enabled and the deck's `@font-face` rules
point at local `.ttf` files, the exported PPTX silently contains zero
embedded fonts. PowerPoint opens it without complaint, renders
everything in a system fallback font, and the deck's typography is
broken — with no indication anything went wrong.

The root cause is a Chromium same-origin restriction: `fetch()` from a
`file://` page targeting another `file://` URL is blocked by default.
`autoEmbedFonts` calls `fetch()` on every `@font-face` URL to pull the
font data into the PPTX blob, so local font files silently 404, the
per-family `console.warn` fires and scrolls past, and the export
"succeeds" with a 15 KB PPTX instead of the expected ~300 KB.

The fix is one flag: `--allow-file-access-from-files` in the Puppeteer
launch args. With it, the existing embed pipeline works for local fonts
with no other changes. Without it, `autoEmbedFonts: true` is
effectively broken for any caller using a local font workflow — which
is the recommended approach for offline builds, since the alternative
(relying on Google Fonts CDN) produces a PPTX that embeds nothing if
run without internet access or if the CDN sheet can't be scanned due
to CORS (which it can't — see the SecurityError path in
`getAutoDetectedFonts`).

This PR adds the flag to the default Chrome/Chromium/Edge launch args.

## Security posture

Per Chromium's docs, this flag only affects `file://` origins. It does
not weaken security when the exporter is pointed at `http(s)://` URLs.
The exporter is a build tool that runs against author-controlled
files; opening file-to-file access for those is the same trust
boundary as file-to-file `<link>` and `<img>` (which already worked).

Firefox path is unchanged. Firefox manages its own sandboxing via
WebDriver BiDi and does not accept Chrome flags.

## Refactor

Extracted the launch-args computation into an exported helper
`getLaunchArgs(product)` so the default set is unit-testable without
spinning up a browser. Callers who need to override or extend the
args can import and modify the returned array.

## Tests

4 new tests in `src/__tests__/node-exporter.test.js`:

- Chrome/Chromium/Edge get `--allow-file-access-from-files`
- Chrome-family retains the existing `--no-sandbox` /
  `--disable-setuid-sandbox` flags
- Firefox returns `[]` (empty args)
- Repeated calls return fresh arrays (no shared mutable state)
