### PR TITLE
feat(fonts): harden auto-embed against @import, silent failures, and slot collisions

### DIFF
--- a/src/__tests__/font-detection.test.js
+++ b/src/__tests__/font-detection.test.js
@@ -1,0 +1,243 @@
+// src/__tests__/font-detection.test.js
+//
+// Tests for the font-detection helpers in src/utils.js — extracted from
+// the exportToPptx pipeline so they can be exercised in isolation:
+//
+//   - getFontsFromStyleSheets: scans an array of CSSStyleSheet-like
+//     objects (including @import chains) for @font-face declarations
+//     matching the requested families.
+//   - classifyFontVariant: maps CSS font-weight / font-style into one of
+//     PowerPoint's four embedded-font slots.
+//   - detectVariantSlotCollisions: flags when multiple weights of the
+//     same family collapse into the same slot (e.g. weight 700 + 900
+//     both landing in `bold`).
+//
+// The @import traversal test in particular covers a real user-hit
+// footgun: `@import url('./fonts.css')` in a theme file used to escape
+// auto-embed discovery and silently produce a fonts-less PPTX.
+
+import { describe, it, expect } from 'vitest';
+import {
+  getFontsFromStyleSheets,
+  classifyFontVariant,
+  detectVariantSlotCollisions,
+} from '../utils.js';
+
+// -- Helpers to build CSSStyleSheet-like fixtures without a real DOM ----------
+
+function fontFaceRule({ family, src, weight = '400', style = 'normal' }) {
+  return {
+    constructor: { name: 'CSSFontFaceRule' },
+    style: {
+      getPropertyValue: (prop) => {
+        if (prop === 'font-family') return `"${family}"`;
+        if (prop === 'src') return src;
+        if (prop === 'font-weight') return String(weight);
+        if (prop === 'font-style') return style;
+        return '';
+      },
+    },
+  };
+}
+
+function importRule(importedSheet) {
+  return {
+    constructor: { name: 'CSSImportRule' },
+    styleSheet: importedSheet,
+  };
+}
+
+function makeSheet(rules) {
+  return { cssRules: rules };
+}
+
+// -----------------------------------------------------------------------------
+
+describe('getFontsFromStyleSheets', () => {
+  it('discovers @font-face rules for families in usedFamilies', () => {
+    const sheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('fonts/Inter-Regular.ttf')", weight: '400' }),
+      fontFaceRule({ family: 'Merriweather', src: "url('fonts/Merri.ttf')", weight: '400' }),
+    ]);
+
+    const used = new Set(['Inter']);
+    const found = getFontsFromStyleSheets(used, [sheet]);
+    expect(found).toHaveLength(1);
+    expect(found[0].name).toBe('Inter');
+    expect(found[0].url).toBe('fonts/Inter-Regular.ttf');
+  });
+
+  it('recurses into @import chains — the common `theme.css imports fonts.css` pattern', () => {
+    // Fixture: `fonts.css` (imported) declares @font-face for Inter Regular + Bold.
+    // `theme.css` (top-level) contains only an @import pointing at fonts.css.
+    // Before this fix, top-level scanning of `theme.css` found zero @font-face
+    // rules and auto-embed produced a fonts-less PPTX (~15 KB instead of ~300 KB).
+    const importedSheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('fonts/Inter-Regular.ttf')", weight: '400' }),
+      fontFaceRule({ family: 'Inter', src: "url('fonts/Inter-Bold.ttf')", weight: '700' }),
+    ]);
+    const topSheet = makeSheet([importRule(importedSheet)]);
+
+    const used = new Set(['Inter']);
+    const found = getFontsFromStyleSheets(used, [topSheet]);
+    expect(found).toHaveLength(2);
+    const weights = found.map((f) => f.weight).sort();
+    expect(weights).toEqual(['400', '700']);
+  });
+
+  it('recurses through multiple levels of @import', () => {
+    // A imports B, B imports C, C declares the actual @font-face.
+    const level3 = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('a.ttf')", weight: '400' }),
+    ]);
+    const level2 = makeSheet([importRule(level3)]);
+    const level1 = makeSheet([importRule(level2)]);
+
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [level1]);
+    expect(found).toHaveLength(1);
+    expect(found[0].url).toBe('a.ttf');
+  });
+
+  it('does not loop forever on cyclic @import graphs', () => {
+    // Pathological but survivable: sheet A imports sheet B; sheet B
+    // imports sheet A back. Should terminate rather than stack-overflow.
+    const a = makeSheet([]);
+    const b = makeSheet([importRule(a)]);
+    a.cssRules = [
+      importRule(b),
+      fontFaceRule({ family: 'Inter', src: "url('cyclic.ttf')" }),
+    ];
+
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [a]);
+    expect(found).toHaveLength(1);
+    expect(found[0].url).toBe('cyclic.ttf');
+  });
+
+  it('deduplicates by URL across multiple sheets', () => {
+    const sheetA = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('inter.ttf')", weight: '400' }),
+    ]);
+    const sheetB = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('inter.ttf')", weight: '400' }),
+    ]);
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [sheetA, sheetB]);
+    expect(found).toHaveLength(1);
+  });
+
+  it('preserves font-weight and font-style on each detected entry', () => {
+    const sheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('a.ttf')", weight: '400', style: 'normal' }),
+      fontFaceRule({ family: 'Inter', src: "url('b.ttf')", weight: '700', style: 'italic' }),
+    ]);
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [sheet]);
+    expect(found).toHaveLength(2);
+    const regular = found.find((f) => f.url === 'a.ttf');
+    const boldItalic = found.find((f) => f.url === 'b.ttf');
+    expect(regular).toMatchObject({ weight: '400', style: 'normal' });
+    expect(boldItalic).toMatchObject({ weight: '700', style: 'italic' });
+  });
+
+  it('survives a stylesheet that throws on cssRules access (cross-origin)', () => {
+    // Simulates the SecurityError thrown by cross-origin sheets (e.g.
+    // Google Fonts CSS without CORS headers). The scan should continue
+    // on to other sheets rather than propagating the exception.
+    const hostileSheet = {
+      href: 'https://example.com/blocked.css',
+      get cssRules() {
+        throw new Error('SecurityError: cross-origin');
+      },
+    };
+    const okSheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('local.ttf')", weight: '400' }),
+    ]);
+
+    expect(() =>
+      getFontsFromStyleSheets(new Set(['Inter']), [hostileSheet, okSheet])
+    ).not.toThrow();
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [hostileSheet, okSheet]);
+    expect(found).toHaveLength(1);
+    expect(found[0].url).toBe('local.ttf');
+  });
+});
+
+describe('classifyFontVariant', () => {
+  it('maps numeric weights to bold/regular based on the 600 threshold', () => {
+    expect(classifyFontVariant(400, 'normal')).toBe('regular');
+    expect(classifyFontVariant(500, 'normal')).toBe('regular'); // Medium is not bold
+    expect(classifyFontVariant(600, 'normal')).toBe('bold'); // SemiBold rounds up
+    expect(classifyFontVariant(700, 'normal')).toBe('bold');
+    expect(classifyFontVariant(900, 'normal')).toBe('bold'); // Black collapses into bold slot
+  });
+
+  it('handles the keyword weights (bold, bolder, lighter, normal)', () => {
+    expect(classifyFontVariant('bold', 'normal')).toBe('bold');
+    expect(classifyFontVariant('bolder', 'normal')).toBe('bold');
+    expect(classifyFontVariant('lighter', 'normal')).toBe('regular');
+    expect(classifyFontVariant('normal', 'normal')).toBe('regular');
+  });
+
+  it('classifies italic and oblique into italic slots', () => {
+    expect(classifyFontVariant(400, 'italic')).toBe('italic');
+    expect(classifyFontVariant(400, 'oblique')).toBe('italic');
+    expect(classifyFontVariant(700, 'italic')).toBe('boldItalic');
+  });
+
+  it('defaults to regular for missing / undefined inputs', () => {
+    expect(classifyFontVariant(undefined, undefined)).toBe('regular');
+    expect(classifyFontVariant(null, null)).toBe('regular');
+    expect(classifyFontVariant('', '')).toBe('regular');
+  });
+
+  it('handles nonsense weights by falling back to 400', () => {
+    expect(classifyFontVariant('mystery', 'normal')).toBe('regular');
+  });
+});
+
+describe('detectVariantSlotCollisions', () => {
+  it('reports weight 700 + weight 900 for same family as a bold-slot collision', () => {
+    // The workflow-relevant case: Inter Bold + Inter Black both classify
+    // as `bold`. Black glyphs silently get merged into Bold's slot.
+    const entries = [
+      { name: 'Inter', weight: 400, style: 'normal' },
+      { name: 'Inter', weight: 700, style: 'normal' },
+      { name: 'Inter', weight: 900, style: 'normal' },
+    ];
+    const collisions = detectVariantSlotCollisions(entries);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].family).toBe('Inter');
+    expect(collisions[0].variant).toBe('bold');
+    expect(collisions[0].weights).toEqual(['700', '900']);
+  });
+
+  it('does not report a collision when weights land in different slots', () => {
+    const entries = [
+      { name: 'Inter', weight: 400, style: 'normal' },
+      { name: 'Inter', weight: 700, style: 'normal' },
+    ];
+    expect(detectVariantSlotCollisions(entries)).toEqual([]);
+  });
+
+  it('separates collisions per family', () => {
+    const entries = [
+      { name: 'Inter', weight: 700, style: 'normal' },
+      { name: 'Inter', weight: 900, style: 'normal' },
+      { name: 'Merriweather', weight: 800, style: 'italic' },
+      { name: 'Merriweather', weight: 900, style: 'italic' },
+    ];
+    const collisions = detectVariantSlotCollisions(entries);
+    expect(collisions).toHaveLength(2);
+    const families = collisions.map((c) => c.family).sort();
+    expect(families).toEqual(['Inter', 'Merriweather']);
+  });
+
+  it('does not report a spurious collision when the same weight appears twice', () => {
+    // Two @font-face rules at weight 400 for the same family (e.g.
+    // pointing at Latin vs Cyrillic subsets) should NOT trigger the
+    // collision warning — same weight, no distinct face is being lost.
+    const entries = [
+      { name: 'Inter', weight: 400, style: 'normal' },
+      { name: 'Inter', weight: 400, style: 'normal' },
+    ];
+    expect(detectVariantSlotCollisions(entries)).toEqual([]);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ import {
   generateCustomShapeSVG,
   getUsedFontFamilies,
   getAutoDetectedFonts,
+  classifyFontVariant,
+  detectVariantSlotCollisions,
   extractTableData,
   collectTextParts,
 } from './utils.js';
@@ -149,28 +151,9 @@ export async function exportToPptx(target, options = {}) {
   let rawFonts = options.fonts || [];
   let fontsToEmbed;
 
-  // Classify a CSS font-weight / font-style pair into one of the four slots
-  // that PowerPoint's embedded-font list supports: regular, bold, italic,
-  // boldItalic. Anything at weight >= 600 counts as bold; italic/oblique
-  // counts as italic.
-  const classifyVariant = (weight, style) => {
-    const wRaw = String(weight || '400').toLowerCase().trim();
-    let w = parseInt(wRaw, 10);
-    if (isNaN(w)) {
-      if (wRaw === 'bold' || wRaw === 'bolder') w = 700;
-      else if (wRaw === 'lighter') w = 300;
-      else w = 400;
-    }
-    const isBold = w >= 600;
-    const sRaw = String(style || 'normal').toLowerCase();
-    const isItalic = sRaw === 'italic' || sRaw === 'oblique';
-    if (isBold && isItalic) return 'boldItalic';
-    if (isBold) return 'bold';
-    if (isItalic) return 'italic';
-    return 'regular';
-  };
-
   // Group by (name, variant) so each PowerPoint slot gets its own font.
+  // classifyFontVariant lives in utils.js so it can be unit-tested and
+  // reused for collision detection below.
   const uniqueFonts = new Map();
   const addToGroup = (name, variant, url) => {
     const key = name + '::' + variant;
@@ -180,8 +163,13 @@ export async function exportToPptx(target, options = {}) {
     uniqueFonts.get(key).urls.add(url);
   };
 
+  // Track every raw entry so we can detect variant-slot collisions
+  // (e.g. Inter@700 and Inter@900 both landing in the `bold` slot).
+  const rawFontDescriptors = [];
+
   for (const f of rawFonts) {
-    const variant = classifyVariant(f.weight, f.style);
+    const variant = classifyFontVariant(f.weight, f.style);
+    rawFontDescriptors.push({ name: f.name, weight: f.weight, style: f.style });
     if (f.url) addToGroup(f.name, variant, f.url);
     if (f.urls) {
       for (const url of f.urls) addToGroup(f.name, variant, url);
@@ -197,16 +185,34 @@ export async function exportToPptx(target, options = {}) {
 
     // C. Merge, keyed by (name, variant) so Bold does not collapse into Regular
     for (const autoFont of detectedFonts) {
-      const variant = classifyVariant(autoFont.weight, autoFont.style);
+      const variant = classifyFontVariant(autoFont.weight, autoFont.style);
+      rawFontDescriptors.push({ name: autoFont.name, weight: autoFont.weight, style: autoFont.style });
       addToGroup(autoFont.name, variant, autoFont.url);
     }
 
     if (detectedFonts.length > 0) {
       console.log(
         'Auto-detected fonts:',
-        detectedFonts.map((f) => `${f.name} (${classifyVariant(f.weight, f.style)})`)
+        detectedFonts.map((f) => `${f.name} (${classifyFontVariant(f.weight, f.style)})`)
       );
     }
+  }
+
+  // Warn when two @font-face declarations with materially different
+  // weights land in the same PowerPoint slot. Most common example:
+  // declaring Inter at weight 700 alongside weight 900 — both classify as
+  // `bold`, so weight 900 glyphs silently get merged into (and mostly
+  // overwritten by) weight 700. To render Inter Black distinctly, declare
+  // it under a separate CSS family (e.g. `font-family: 'Inter Black'`)
+  // rather than a heavier weight of the same family.
+  const collisions = detectVariantSlotCollisions(rawFontDescriptors);
+  for (const c of collisions) {
+    console.warn(
+      `dom-to-pptx: font "${c.family}" declares multiple weights (${c.weights.join(', ')}) ` +
+        `that collapse into PowerPoint's "${c.variant}" slot. Only one will render distinctly. ` +
+        `Declare the heavier weight under a separate CSS family (e.g. 'Inter Black') if you ` +
+        `need it to render as a distinct face.`
+    );
   }
 
   fontsToEmbed = Array.from(uniqueFonts.values()).map((entry) => ({
@@ -231,9 +237,15 @@ export async function exportToPptx(target, options = {}) {
     const embedder = new PPTXEmbedFonts();
     await embedder.loadZip(zip);
 
-    // Fetch and Embed Concurrently
+    // Fetch and Embed Concurrently. Track success/failure per (family,variant)
+    // so we can print a structured summary at the end — a silent no-op on
+    // font embedding is one of the sharpest workflow sharp edges (a 15 KB
+    // PPTX with no fonts embedded looks identical to a 15 KB PPTX with
+    // fonts intentionally excluded).
+    const embedResults = [];
     await Promise.all(
       fontsToEmbed.map(async (fontCfg) => {
+        const label = `${fontCfg.name} (${fontCfg.variant || 'regular'})`;
         try {
           if (fontCfg.urls.length === 0) {
             throw new Error(`No URLs found for font family ${fontCfg.name}`);
@@ -243,7 +255,7 @@ export async function exportToPptx(target, options = {}) {
           const subsets = await Promise.all(
             fontCfg.urls.map(async (url) => {
               const response = await fetch(url);
-              if (!response.ok) throw new Error(`Failed to fetch ${url}`);
+              if (!response.ok) throw new Error(`Failed to fetch ${url} (HTTP ${response.status})`);
               const buffer = await response.arrayBuffer();
 
               // Infer type
@@ -262,11 +274,36 @@ export async function exportToPptx(target, options = {}) {
             undefined,
             fontCfg.variant || 'regular'
           );
+          embedResults.push({ label, ok: true });
         } catch (e) {
+          const reason = e && e.message ? e.message : String(e);
+          embedResults.push({ label, ok: false, reason });
           console.warn(`Failed to embed font family: ${fontCfg.name}`, e);
         }
       })
     );
+
+    // Structured summary. Users routinely miss the per-family console.warn
+    // above (especially when fetch() 404s during a headless build), so we
+    // always print an explicit summary line — including a highly visible
+    // error line if any embed failed. This turns a silent no-op into a
+    // loud one.
+    const succeeded = embedResults.filter((r) => r.ok);
+    const failed = embedResults.filter((r) => !r.ok);
+    if (succeeded.length > 0) {
+      console.log(
+        `dom-to-pptx: embedded ${succeeded.length} font variant(s): ` + succeeded.map((r) => r.label).join(', ')
+      );
+    }
+    if (failed.length > 0) {
+      console.error(
+        `dom-to-pptx: FAILED to embed ${failed.length} font variant(s). ` +
+          `PowerPoint will fall back to a system font, breaking the design. Details:`
+      );
+      for (const r of failed) {
+        console.error(`  - ${r.label}: ${r.reason}`);
+      }
+    }
 
     await embedder.updateFiles();
     if (options.skipNormalize !== true) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1091,77 +1091,171 @@ export function getUsedFontFamilies(root) {
   return families;
 }
 
+// Helper to extract a clean URL from a CSS `src` string. Exported so
+// getFontsFromStyleSheets can be unit-tested against synthetic CSSOM.
+function extractFontUrl(srcStr) {
+  // Look for url("..."), url('...'), or url(...).
+  // Prefer woff/ttf/otf; fall back to whatever is available.
+  const matches = srcStr.match(/url\((['"]?)(.*?)\1\)/g);
+  if (!matches) return null;
+
+  let chosenUrl = null;
+  for (const match of matches) {
+    const urlRaw = match.replace(/url\((['"]?)(.*?)\1\)/, '$2');
+    // Skip data URIs for now (unless we want to support base64 embedding).
+    if (urlRaw.startsWith('data:')) continue;
+
+    if (urlRaw.includes('.ttf') || urlRaw.includes('.otf') || urlRaw.includes('.woff')) {
+      chosenUrl = urlRaw;
+      break;
+    }
+    if (!chosenUrl) chosenUrl = urlRaw;
+  }
+  return chosenUrl;
+}
+
 /**
- * Scans document.styleSheets to find @font-face URLs for the requested families.
- * Returns an array of { name, url } objects.
+ * Walk a list of CSSStyleSheet-like objects and collect @font-face
+ * declarations whose family matches usedFamilies.
+ *
+ * Recurses into @import rules so that a `theme.css` containing
+ * `@import url('./fonts.css');` still surfaces the @font-face
+ * declarations inside `fonts.css`. Without this, a common CSS
+ * organisation (imports for shared type stacks) silently produces an
+ * empty embedded-font list.
+ *
+ * Extracted from getAutoDetectedFonts so it can be exercised in unit
+ * tests without depending on document.styleSheets.
+ *
+ * @param {Set<string>} usedFamilies
+ * @param {ArrayLike<CSSStyleSheet>} styleSheets
+ * @returns {Array<{name: string, url: string, weight: string, style: string}>}
  */
-export async function getAutoDetectedFonts(usedFamilies) {
+export function getFontsFromStyleSheets(usedFamilies, styleSheets) {
   const foundFonts = [];
   const processedUrls = new Set();
+  const visitedSheets = new Set(); // Guard against cyclic @import graphs.
 
-  // Helper to extract clean URL from CSS src string
-  const extractUrl = (srcStr) => {
-    // Look for url("...") or url('...') or url(...)
-    // Prioritize woff, ttf, otf. Avoid woff2 if possible as handling is harder,
-    // but if it's the only one, take it (convert logic handles it best effort).
-    const matches = srcStr.match(/url\((['"]?)(.*?)\1\)/g);
-    if (!matches) return null;
+  const walk = (sheet) => {
+    if (!sheet || visitedSheets.has(sheet)) return;
+    visitedSheets.add(sheet);
 
-    // Filter for preferred formats
-    let chosenUrl = null;
-    for (const match of matches) {
-      const urlRaw = match.replace(/url\((['"]?)(.*?)\1\)/, '$2');
-      // Skip data URIs for now (unless you want to support base64 embedding)
-      if (urlRaw.startsWith('data:')) continue;
-
-      if (urlRaw.includes('.ttf') || urlRaw.includes('.otf') || urlRaw.includes('.woff')) {
-        chosenUrl = urlRaw;
-        break; // Found a good one
-      }
-      // Fallback
-      if (!chosenUrl) chosenUrl = urlRaw;
-    }
-    return chosenUrl;
-  };
-
-  for (const sheet of Array.from(document.styleSheets)) {
+    let rules;
     try {
-      // Accessing cssRules on cross-origin sheets (like Google Fonts) might fail
-      // if CORS headers aren't set. We wrap in try/catch.
-      const rules = sheet.cssRules || sheet.rules;
-      if (!rules) continue;
+      rules = sheet.cssRules || sheet.rules;
+    } catch (e) {
+      // SecurityError is common for cross-origin sheets (Google Fonts etc.);
+      // we cannot scan those via CSSOM.
+      console.warn('Cannot scan stylesheet for fonts (CORS restriction):', sheet.href, e && e.message);
+      return;
+    }
+    if (!rules) return;
 
-      for (const rule of Array.from(rules)) {
-        if (rule.constructor.name === 'CSSFontFaceRule' || rule.type === 5) {
-          const familyName = rule.style.getPropertyValue('font-family').replace(/['"]/g, '').trim();
+    for (const rule of Array.from(rules)) {
+      // CSSImportRule (type === 3): recurse into the imported sheet so
+      // that `@import url('./fonts.css')` in a top-level stylesheet
+      // still surfaces its @font-face rules.
+      if (rule.constructor.name === 'CSSImportRule' || rule.type === 3) {
+        walk(rule.styleSheet);
+        continue;
+      }
 
-          if (usedFamilies.has(familyName)) {
-            const src = rule.style.getPropertyValue('src');
-            const url = extractUrl(src);
+      if (rule.constructor.name === 'CSSFontFaceRule' || rule.type === 5) {
+        const familyName = rule.style.getPropertyValue('font-family').replace(/['"]/g, '').trim();
 
-            if (url && !processedUrls.has(url)) {
-              processedUrls.add(url);
-              // Preserve font-weight and font-style so downstream grouping can
-              // classify each @font-face declaration into one of PowerPoint's
-              // four embedded-font slots (regular / bold / italic / boldItalic).
-              // Without this, all variants for a family collapse into a single
-              // Regular embed and PowerPoint synthesises fake bold.
-              const weight = rule.style.getPropertyValue('font-weight').trim() || '400';
-              const fontStyle = (rule.style.getPropertyValue('font-style').trim() || 'normal').toLowerCase();
-              foundFonts.push({ name: familyName, url: url, weight: weight, style: fontStyle });
-            }
-          }
+        if (!usedFamilies.has(familyName)) continue;
+
+        const src = rule.style.getPropertyValue('src');
+        const url = extractFontUrl(src);
+
+        if (url && !processedUrls.has(url)) {
+          processedUrls.add(url);
+          // Preserve font-weight and font-style so downstream grouping can
+          // classify each @font-face declaration into one of PowerPoint's
+          // four embedded-font slots (regular / bold / italic / boldItalic).
+          const weight = rule.style.getPropertyValue('font-weight').trim() || '400';
+          const fontStyle = (rule.style.getPropertyValue('font-style').trim() || 'normal').toLowerCase();
+          foundFonts.push({ name: familyName, url: url, weight: weight, style: fontStyle });
         }
       }
-    } catch (e) {
-      // SecurityError is common for external stylesheets (CORS).
-      // We cannot scan those automatically via CSSOM.
-      console.warn('error:', e);
-      console.warn('Cannot scan stylesheet for fonts (CORS restriction):', sheet.href);
     }
+  };
+
+  for (const sheet of Array.from(styleSheets)) {
+    walk(sheet);
   }
 
   return foundFonts;
+}
+
+/**
+ * Scans document.styleSheets to find @font-face URLs for the requested
+ * families. Returns an array of { name, url, weight, style } objects.
+ *
+ * Thin wrapper around getFontsFromStyleSheets that reads the ambient
+ * document.styleSheets. Kept async for backward compatibility with the
+ * previous signature, though the body is now synchronous.
+ */
+export async function getAutoDetectedFonts(usedFamilies) {
+  return getFontsFromStyleSheets(usedFamilies, document.styleSheets);
+}
+
+/**
+ * Map a CSS font-weight / font-style pair into one of the four slots
+ * that PowerPoint's embedded-font list supports: regular, bold, italic,
+ * boldItalic. Anything at weight >= 600 counts as bold; italic/oblique
+ * counts as italic.
+ *
+ * Exported so callers can classify a family's variants ahead of grouping,
+ * and so the classification is unit-testable.
+ */
+export function classifyFontVariant(weight, style) {
+  const wRaw = String(weight || '400').toLowerCase().trim();
+  let w = parseInt(wRaw, 10);
+  if (isNaN(w)) {
+    if (wRaw === 'bold' || wRaw === 'bolder') w = 700;
+    else if (wRaw === 'lighter') w = 300;
+    else w = 400;
+  }
+  const isBold = w >= 600;
+  const sRaw = String(style || 'normal').toLowerCase();
+  const isItalic = sRaw === 'italic' || sRaw === 'oblique';
+  if (isBold && isItalic) return 'boldItalic';
+  if (isBold) return 'bold';
+  if (isItalic) return 'italic';
+  return 'regular';
+}
+
+/**
+ * Detect when multiple @font-face declarations for the same family map
+ * into the same PowerPoint slot with materially different weights.
+ *
+ * PowerPoint's embedded-font model only exposes four slots per family
+ * (regular / bold / italic / boldItalic). CSS weight 700 (Bold) and
+ * weight 900 (Black) both classify as `bold`; the second one silently
+ * loses glyphs during embed. This is a real workflow surprise for anyone
+ * declaring `font-family: 'Inter'; font-weight: 900` alongside 700.
+ *
+ * Returns an array of { family, variant, weights } collision descriptors
+ * so callers can emit an actionable warning.
+ *
+ * @param {Array<{name: string, weight?: string|number, style?: string}>} fontEntries
+ */
+export function detectVariantSlotCollisions(fontEntries) {
+  const seen = new Map(); // key = "family::variant" -> Set of weight strings
+  for (const f of fontEntries) {
+    const variant = classifyFontVariant(f.weight, f.style);
+    const key = f.name + '::' + variant;
+    if (!seen.has(key)) seen.set(key, new Set());
+    seen.get(key).add(String(f.weight ?? '400').trim());
+  }
+  const collisions = [];
+  for (const [key, weights] of seen) {
+    if (weights.size < 2) continue;
+    const [family, variant] = key.split('::');
+    collisions.push({ family, variant, weights: Array.from(weights).sort() });
+  }
+  return collisions;
 }
 
 /**


### PR DESCRIPTION
## Summary

Three related improvements to the font auto-embed pipeline. All three
respond to real workflow surprises hit while building a designed
25-slide deck against v2.0.2 (following the merge of #52 / #53):

1. **Traverse `@import` chains during font detection.** A `theme.css`
   containing `@import url('./fonts.css');` used to hide its
   `@font-face` rules from auto-detection — the exported PPTX came
   out ~15 KB (no fonts) instead of the expected ~300 KB.
2. **Announce embed failures with a structured summary.** Per-family
   `console.warn` failures were trivial to miss. Silent no-op is the
   worst failure mode of the auto-embed pipeline.
3. **Warn on weight-slot collisions.** Declaring Inter at both weight
   700 and weight 900 silently discards weight 900 glyphs during
   merge (PowerPoint only has four slots per family).

## The three changes in detail

### 1. `@import` traversal

`getAutoDetectedFonts` iterated `document.styleSheets` and inspected
each rule for `CSSFontFaceRule` directly. Any `@font-face`
declarations inside an `@import`'d stylesheet were invisible.

This PR extracts the walk into a testable helper
(`getFontsFromStyleSheets`) that recurses into
`CSSImportRule.styleSheet` with a visited-set guard against cyclic
`@import` graphs.

Common CSS organization pattern that was breaking:

```css
/* theme.css — top-level, linked from every slide */
@import url('./fonts.css');
:root { --font-display: 'Inter', sans-serif; }
```

```css
/* fonts.css — invisible to auto-detect before this PR */
@font-face { font-family: 'Inter'; font-weight: 400; src: url('...'); }
@font-face { font-family: 'Inter'; font-weight: 700; src: url('...'); }
```

### 2. Structured embed-outcome summary

Per-family fetch failures previously went to `console.warn` and were
trivial to miss. When Chromium's `--allow-file-access-from-files` flag
was omitted (fixed in #55), fetches for local `file://` font URLs
silently failed and the export completed with no fonts embedded — a
15 KB PPTX that PowerPoint renders in a fallback system font.

Every embed attempt now records success or failure per (family,
variant). After the embed loop:

- `console.log` lists successful embeds (`Inter (regular), Inter (bold)`)
- `console.error` announces failures with a leading line
  `FAILED to embed N font variant(s). PowerPoint will fall back to a
  system font, breaking the design.` followed by one line per failure
  with the specific reason (URL, HTTP status, or JS error).

### 3. Weight-slot collision warning

PowerPoint's embedded-font list has only four slots per family
(`regular`, `bold`, `italic`, `boldItalic`). CSS weight 700 (Bold) and
weight 900 (Black) both classify as `bold`. When two distinct weights
target the same slot, only one renders — the other's glyphs are lost
during merge.

Extracted `classifyFontVariant` to `src/utils.js` (was previously a
local function inside `exportToPptx`) so it can be unit-tested and
reused by a new `detectVariantSlotCollisions` helper. When
`exportToPptx` sees two distinct weights land in the same slot, it
emits a specific `console.warn` naming the family, the slot, the
colliding weights, and the recommended CSS workaround (declare the
heavier weight under a separate CSS family, e.g. `font-family: 'Inter
Black'`).

## Tests

16 new tests in `src/__tests__/font-detection.test.js`:

- `getFontsFromStyleSheets`:
  - Single-level `@font-face` discovery
  - `@import` traversal (single level)
  - Multi-level `@import` chains
  - Cyclic `@import` graphs (must terminate)
  - Cross-origin sheet `SecurityError` doesn't abort scanning
  - URL deduplication across sheets
  - Weight/style preservation on detected entries
- `classifyFontVariant`:
  - Numeric weights across the 600-boundary
  - Keyword weights (`bold`, `bolder`, `lighter`, `normal`)
  - `italic` / `oblique`
  - Missing / undefined inputs
  - Nonsense weight strings
- `detectVariantSlotCollisions`:
  - Real collision (weight 700 + 900 for same family)
  - Non-collision (weight 400 + 700, different slots)
  - Per-family separation
  - Duplicate-weight is not a collision

All 79 pre-existing tests continue to pass.
