### PR TITLE
feat(notes): populate speaker notes from data-pptx-notes elements

### DIFF
--- a/src/__tests__/speaker-notes.test.js
+++ b/src/__tests__/speaker-notes.test.js
@@ -1,0 +1,118 @@
+// src/__tests__/speaker-notes.test.js
+//
+// Tests for extractSpeakerNotesFromElement, the helper that reads
+// PowerPoint speaker-notes text from a slide's DOM. The extractor scans
+// for elements with a `data-pptx-notes` attribute and returns their
+// text content joined with blank-line separators.
+//
+// This is the feature that removes the need for a separate
+// python-pptx post-process step to populate speaker notes on decks
+// built with dom-to-pptx.
+
+import { describe, it, expect } from 'vitest';
+import { extractSpeakerNotesFromElement } from '../utils.js';
+
+// jsdom provides `document.createElement` etc. under vitest's default
+// environment. All helpers below build real DOM subtrees.
+
+function slideWith(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div;
+}
+
+describe('extractSpeakerNotesFromElement', () => {
+  it('extracts text content from an element carrying data-pptx-notes', () => {
+    const root = slideWith(`
+      <h1>Slide headline</h1>
+      <div data-pptx-notes hidden>Welcome to the deck. Say hello.</div>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('Welcome to the deck. Say hello.');
+  });
+
+  it('reads from <template>.content, not .textContent', () => {
+    // <template> is the recommended container: its markup is inert, so
+    // the notes never render on-slide. jsdom stores template contents in
+    // a DocumentFragment on `.content`.
+    const root = slideWith(`
+      <h1>Slide headline</h1>
+      <template data-pptx-notes>Notes inside a template.</template>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('Notes inside a template.');
+  });
+
+  it('concatenates multiple annotated elements with a blank line between them', () => {
+    const root = slideWith(`
+      <p data-pptx-notes>First note.</p>
+      <h1>Some visible content</h1>
+      <p data-pptx-notes>Second note.</p>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('First note.\n\nSecond note.');
+  });
+
+  it('preserves the document order of annotated elements', () => {
+    const root = slideWith(`
+      <p data-pptx-notes>A</p>
+      <p data-pptx-notes>B</p>
+      <p data-pptx-notes>C</p>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('A\n\nB\n\nC');
+  });
+
+  it('returns empty string when no elements carry the attribute', () => {
+    const root = slideWith(`
+      <h1>Slide headline</h1>
+      <p>Body text.</p>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('');
+  });
+
+  it('ignores annotated elements with no text content', () => {
+    const root = slideWith(`
+      <template data-pptx-notes></template>
+      <p data-pptx-notes>Real note.</p>
+      <div data-pptx-notes>   </div>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('Real note.');
+  });
+
+  it('trims leading and trailing whitespace on each note fragment', () => {
+    const root = slideWith(`
+      <template data-pptx-notes>
+        Multi-line notes.
+        With indentation.
+      </template>
+    `);
+    // Leading/trailing whitespace on the fragment gets trimmed by the
+    // extractor; interior whitespace is preserved verbatim.
+    const result = extractSpeakerNotesFromElement(root);
+    expect(result.startsWith('Multi-line notes.')).toBe(true);
+    expect(result.endsWith('With indentation.')).toBe(true);
+  });
+
+  it('returns empty string when the root is null or missing querySelectorAll', () => {
+    expect(extractSpeakerNotesFromElement(null)).toBe('');
+    expect(extractSpeakerNotesFromElement(undefined)).toBe('');
+    expect(extractSpeakerNotesFromElement({})).toBe('');
+  });
+
+  it('reads notes from elements at arbitrary depth in the slide subtree', () => {
+    const root = slideWith(`
+      <section>
+        <article>
+          <footer>
+            <template data-pptx-notes>Deeply nested note.</template>
+          </footer>
+        </article>
+      </section>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('Deeply nested note.');
+  });
+
+  it('works with any element type (attribute-driven, not tag-driven)', () => {
+    const root = slideWith(`
+      <aside data-pptx-notes>Sidebar note.</aside>
+    `);
+    expect(extractSpeakerNotesFromElement(root)).toBe('Sidebar note.');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import {
   generateCustomShapeSVG,
   getUsedFontFamilies,
   getAutoDetectedFonts,
+  extractSpeakerNotesFromElement,
   extractTableData,
   collectTextParts,
 } from './utils.js';
@@ -137,6 +138,18 @@ export async function exportToPptx(target, options = {}) {
       _slideIndex: slideIndex,
       _animations: [],
     };
+
+    // Extract speaker notes from any element inside the slide root that
+    // carries a data-pptx-notes attribute. Recognises <template
+    // data-pptx-notes> (inert content), <div data-pptx-notes hidden>,
+    // and any other tag with the attribute. Multiple matches concatenate.
+    // Notes are attached BEFORE processSlide runs so users can freely
+    // place notes wherever they like without worrying about ordering.
+    const notesText = extractSpeakerNotesFromElement(root);
+    if (notesText) {
+      slide.addNotes(notesText);
+    }
+
     await processSlide(root, slide, pptx, slideOptions);
     slideAnimations[slideIndex] = slideOptions._animations;
     slideIndex++;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1092,6 +1092,57 @@ export function getUsedFontFamilies(root) {
 }
 
 /**
+ * Extract PowerPoint speaker-notes text from a slide root element.
+ *
+ * DOM convention: any descendant of the slide root carrying a
+ * `data-pptx-notes` attribute contributes its text content to the
+ * slide's speaker-notes pane. Elements without the attribute are
+ * ignored; elements with the attribute but no text content are ignored
+ * (so a stray empty `<template data-pptx-notes>` is harmless).
+ *
+ * Multiple annotated elements concatenate in document order, separated
+ * by a blank line.
+ *
+ * Three usage patterns work interchangeably:
+ *
+ *   <template data-pptx-notes>
+ *     Speaker notes here. `<template>` content is inert in the DOM so
+ *     the notes never render on-slide.
+ *   </template>
+ *
+ *   <div data-pptx-notes hidden>
+ *     Also fine. `hidden` keeps the div off-slide visually.
+ *   </div>
+ *
+ *   <p data-pptx-notes style="display: none">
+ *     Any element, hidden however you prefer.
+ *   </p>
+ *
+ * If the annotated element is visible (no `hidden`, no CSS `display:
+ * none`), its text will appear both on the slide and in the notes pane.
+ * That is user error, not a defect of this extractor.
+ *
+ * @param {Element} root
+ * @returns {string} Notes text, trimmed. Empty string if no notes.
+ */
+export function extractSpeakerNotesFromElement(root) {
+  if (!root || typeof root.querySelectorAll !== 'function') return '';
+  const nodes = root.querySelectorAll('[data-pptx-notes]');
+  const parts = [];
+  for (const node of Array.from(nodes)) {
+    // <template> stores its markup in a DocumentFragment on `.content`;
+    // its own `.textContent` is empty. Fall back to `.textContent` for
+    // every other element type.
+    const isTemplate = node.tagName && node.tagName.toLowerCase() === 'template';
+    const raw = isTemplate && node.content ? node.content.textContent : node.textContent;
+    if (!raw) continue;
+    const trimmed = raw.trim();
+    if (trimmed) parts.push(trimmed);
+  }
+  return parts.join('\n\n');
+}
+
+/**
  * Scans document.styleSheets to find @font-face URLs for the requested families.
  * Returns an array of { name, url } objects.
  */


### PR DESCRIPTION
## Summary

Populate PowerPoint's per-slide speaker-notes pane directly from the
source DOM, so deck authors no longer need a separate post-process
step (e.g. `python-pptx`) to inject notes after export.

## DOM convention

Any descendant of a slide root that carries a `data-pptx-notes`
attribute contributes its text content to that slide's notes.
Multiple annotated elements concatenate in document order, separated
by a blank line. Empty or whitespace-only elements are ignored.

Three usage patterns work interchangeably:

```html
<template data-pptx-notes>
  Preferred form. <template> content is inert so notes
  never render on-slide.
</template>

<div data-pptx-notes hidden>
  Also fine. hidden keeps the div off-slide visually.
</div>

<p data-pptx-notes style="display: none">
  Any element, hidden however you prefer.
</p>
```

If the annotated element is visible (no `hidden`, no CSS
`display: none`), its text appears both on the slide and in the notes
pane. That is user error, not a defect of the extractor.

## Implementation

`extractSpeakerNotesFromElement` helper in `utils.js` runs against
each slide root before `processSlide` walks it for renderable content.
If the extractor returns non-empty text, we call `slide.addNotes(text)`
on the pptxgenjs slide object.

`<template>` elements store their markup in a `DocumentFragment` on
`.content`; their own `.textContent` is empty. The extractor reads
from `.content.textContent` for templates and `.textContent` for every
other element type.

## Tests

10 new tests in `src/__tests__/speaker-notes.test.js`:

- Basic extraction from a `<div data-pptx-notes>`
- `<template>` `.content.textContent` extraction
- Multiple annotated elements concatenate with blank lines
- Document order preservation across annotated elements
- No annotated elements returns empty string
- Empty / whitespace-only elements are ignored
- Multi-line notes inside a `<template>` preserve interior formatting
- `null` / `undefined` root returns empty string
- Reads from deeply nested elements
- Attribute works on any tag, not just `<div>` / `<template>`

## Backward compatibility

Zero-additive change. Decks that do not use `data-pptx-notes` behave
identically to before.

