### PR TITLE
fix: make no-wrap text slack inset-aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build": "npx rollup -c",
+    "prepare": "npm run build",
     "lint": "eslint .",
     "format": "prettier --write .",
     "publish:all": "pnpm publish -r --no-git-checks"

--- a/src/__tests__/text-containment.test.js
+++ b/src/__tests__/text-containment.test.js
@@ -1,0 +1,127 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../index.js';
+
+const EMU_PER_PX = 4762.5;
+
+function rect({ left, top, width, height }) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON() {
+      return this;
+    },
+  };
+}
+
+function shapeContainingText(xml, text) {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  const textNode = Array.from(doc.getElementsByTagName('a:t')).find((node) => node.textContent.includes(text));
+  expect(textNode).toBeDefined();
+
+  let shape = textNode;
+  while (shape && shape.localName !== 'sp') {
+    shape = shape.parentNode;
+  }
+  expect(shape).toBeDefined();
+  return shape;
+}
+
+function shapeGeometry(shape) {
+  const offset = shape.getElementsByTagName('a:off')[0];
+  const extent = shape.getElementsByTagName('a:ext')[0];
+  return {
+    x: Number(offset.getAttribute('x')),
+    y: Number(offset.getAttribute('y')),
+    width: Number(extent.getAttribute('cx')),
+    height: Number(extent.getAttribute('cy')),
+  };
+}
+
+describe('bare text containment and no-wrap compatibility', () => {
+  beforeAll(() => {
+    let fillStyle = '';
+    HTMLCanvasElement.prototype.getContext = () => ({
+      get fillStyle() {
+        return fillStyle;
+      },
+      set fillStyle(value) {
+        fillStyle = value;
+      },
+      clearRect: () => {},
+      fillRect: () => {},
+      getImageData: () => ({ data: [0, 0, 0, 255] }),
+    });
+  });
+
+  it('contains wrapping text while retaining width slack for a no-wrap badge', async () => {
+    const slide = document.createElement('div');
+    slide.setAttribute('style', 'position:relative;width:1920px;height:1080px;background:#fff');
+
+    const copy = document.createElement('div');
+    copy.textContent =
+      'Design concept copy deliberately runs long enough to exercise wrapping while preserving the authored right inset.';
+    copy.setAttribute(
+      'style',
+      'position:absolute;left:1052px;top:300px;width:820px;height:320px;color:#111;font-size:24px;line-height:32px;white-space:normal;overflow-wrap:anywhere'
+    );
+
+    const badge = document.createElement('div');
+    badge.textContent = 'NO WRAP';
+    Object.assign(badge.style, {
+      position: 'absolute',
+      left: '48px',
+      top: '48px',
+      width: '120px',
+      height: '32px',
+      color: '#fff',
+      backgroundColor: '#123456',
+      borderTopLeftRadius: '16px',
+      borderTopRightRadius: '16px',
+      borderBottomRightRadius: '16px',
+      borderBottomLeftRadius: '16px',
+      fontSize: '16px',
+      lineHeight: '32px',
+      textAlign: 'center',
+      whiteSpace: 'nowrap',
+    });
+
+    slide.append(copy, badge);
+    document.body.appendChild(slide);
+
+    slide.getBoundingClientRect = () => rect({ left: 0, top: 0, width: 1920, height: 1080 });
+    copy.getBoundingClientRect = () => rect({ left: 1052, top: 300, width: 820, height: 320 });
+    badge.getBoundingClientRect = () => rect({ left: 48, top: 48, width: 120, height: 32 });
+
+    try {
+      const blob = await exportToPptx(slide, {
+        skipDownload: true,
+        autoEmbedFonts: false,
+      });
+      const zip = await JSZip.loadAsync(blob);
+      const xml = await zip.file('ppt/slides/slide1.xml').async('string');
+
+      const copyShape = shapeContainingText(xml, 'Design concept copy');
+      const copyGeometry = shapeGeometry(copyShape);
+      const authoredRightEdge = Math.round((1052 + 820) * EMU_PER_PX);
+      expect(copyGeometry.x + copyGeometry.width).toBeLessThanOrEqual(authoredRightEdge);
+      expect(copyGeometry.width).toBe(Math.round(820 * EMU_PER_PX));
+      expect(copyShape.getElementsByTagName('a:normAutofit')).toHaveLength(1);
+
+      const badgeShape = shapeContainingText(xml, 'NO WRAP');
+      const badgeGeometry = shapeGeometry(badgeShape);
+      expect(badgeGeometry.width).toBe(Math.round(120 * 1.06 * EMU_PER_PX));
+      expect(badgeShape.getElementsByTagName('a:spAutoFit')).toHaveLength(0);
+      expect(badgeShape.getElementsByTagName('a:normAutofit')).toHaveLength(0);
+      expect(badgeShape.getElementsByTagName('a:bodyPr')[0].getAttribute('wrap')).toBe('none');
+    } finally {
+      slide.remove();
+    }
+  });
+});

--- a/src/__tests__/text-containment.test.js
+++ b/src/__tests__/text-containment.test.js
@@ -44,6 +44,16 @@ function shapeGeometry(shape) {
   };
 }
 
+function bodyInsets(shape) {
+  const bodyPr = shape.getElementsByTagName('a:bodyPr')[0];
+  return {
+    left: Number(bodyPr.getAttribute('lIns')),
+    right: Number(bodyPr.getAttribute('rIns')),
+    bottom: Number(bodyPr.getAttribute('bIns')),
+    top: Number(bodyPr.getAttribute('tIns')),
+  };
+}
+
 describe('bare text containment and no-wrap compatibility', () => {
   beforeAll(() => {
     let fillStyle = '';
@@ -120,6 +130,91 @@ describe('bare text containment and no-wrap compatibility', () => {
       expect(badgeShape.getElementsByTagName('a:spAutoFit')).toHaveLength(0);
       expect(badgeShape.getElementsByTagName('a:normAutofit')).toHaveLength(0);
       expect(badgeShape.getElementsByTagName('a:bodyPr')[0].getAttribute('wrap')).toBe('none');
+    } finally {
+      slide.remove();
+    }
+  });
+
+  it('widens no-wrap text by its insets while preserving visible geometry and wrapping containment', async () => {
+    const slide = document.createElement('div');
+    slide.setAttribute('style', 'position:relative;width:1920px;height:1080px;background:#fff');
+
+    const label = document.createElement('div');
+    label.textContent = 'White';
+    label.setAttribute(
+      'style',
+      'position:absolute;color:#111;font-size:9px;line-height:20px;white-space:nowrap;padding-right:4px'
+    );
+
+    const pill = document.createElement('div');
+    pill.textContent = 'COLLECTION PITCH';
+    Object.assign(pill.style, {
+      position: 'absolute',
+      color: '#fff',
+      backgroundColor: '#123456',
+      border: '1px solid #123456',
+      borderRadius: '16px',
+      fontSize: '10px',
+      lineHeight: '16px',
+      textAlign: 'center',
+      whiteSpace: 'nowrap',
+      padding: '8px 18px',
+    });
+
+    const copy = document.createElement('div');
+    copy.textContent = 'Wrapping control remains inside its exact authored width.';
+    copy.setAttribute(
+      'style',
+      'position:absolute;color:#111;font-size:24px;line-height:32px;white-space:normal;padding:0'
+    );
+
+    slide.append(label, pill, copy);
+    document.body.appendChild(slide);
+
+    slide.getBoundingClientRect = () => rect({ left: 0, top: 0, width: 1920, height: 1080 });
+    label.getBoundingClientRect = () =>
+      rect({ left: 1800, top: 530, width: 162446 / EMU_PER_PX, height: 95250 / EMU_PER_PX });
+    pill.getBoundingClientRect = () =>
+      rect({ left: 48, top: 48, width: 752252 / EMU_PER_PX, height: 150019 / EMU_PER_PX });
+    copy.getBoundingClientRect = () => rect({ left: 1052, top: 300, width: 820, height: 320 });
+
+    try {
+      const blob = await exportToPptx(slide, {
+        skipDownload: true,
+        autoEmbedFonts: false,
+      });
+      const zip = await JSZip.loadAsync(blob);
+      const xml = await zip.file('ppt/slides/slide1.xml').async('string');
+
+      const labelShape = shapeContainingText(xml, 'White');
+      const labelGeometry = shapeGeometry(labelShape);
+      expect(labelGeometry.width).toBe(181496);
+      expect(labelGeometry.width - bodyInsets(labelShape).right).toBe(162446);
+      expect(labelGeometry.x + labelGeometry.width).toBeLessThanOrEqual(9144000);
+      expect(bodyInsets(labelShape)).toEqual({ left: 0, right: 19050, bottom: 0, top: 0 });
+
+      const pillTextShape = shapeContainingText(xml, 'COLLECTION PITCH');
+      const pillTextGeometry = shapeGeometry(pillTextShape);
+      expect(pillTextGeometry.x).toBe(142875);
+      expect(pillTextGeometry.width).toBe(923702);
+      expect(pillTextGeometry.width - bodyInsets(pillTextShape).left - bodyInsets(pillTextShape).right).toBe(752252);
+      expect(pillTextGeometry.x + pillTextGeometry.width).toBeLessThanOrEqual(9144000);
+      expect(bodyInsets(pillTextShape)).toEqual({ left: 85725, right: 85725, bottom: 38100, top: 38100 });
+
+      const doc = new DOMParser().parseFromString(xml, 'text/xml');
+      const visiblePill = Array.from(doc.getElementsByTagName('p:sp')).find((shape) => {
+        const geometry = shapeGeometry(shape);
+        return !shape.getElementsByTagName('a:t').length && geometry.x === 228600 && geometry.width === 752252;
+      });
+      expect(visiblePill).toBeDefined();
+      expect(shapeGeometry(visiblePill)).toEqual({ x: 228600, y: 228600, width: 752252, height: 150019 });
+
+      const copyShape = shapeContainingText(xml, 'Wrapping control');
+      const copyGeometry = shapeGeometry(copyShape);
+      expect(copyGeometry.width).toBe(Math.round(820 * EMU_PER_PX));
+      expect(copyGeometry.x + copyGeometry.width).toBeLessThanOrEqual(Math.round((1052 + 820) * EMU_PER_PX));
+      expect(bodyInsets(copyShape)).toEqual({ left: 0, right: 0, bottom: 0, top: 0 });
+      expect(copyShape.getElementsByTagName('a:bodyPr')[0].getAttribute('wrap')).toBe('square');
     } finally {
       slide.remove();
     }

--- a/src/__tests__/text-whitespace.test.js
+++ b/src/__tests__/text-whitespace.test.js
@@ -116,6 +116,13 @@ describe('withTextWidthSlack', () => {
     expect(out.w).toBeCloseTo(0.12);
   });
 
+  it('covers the horizontal text insets when they exceed the width floor', () => {
+    const out = withTextWidthSlack(box({ margin: [6.75, 6.75, 3, 3] }), 'center');
+    expect(out.w).toBeCloseTo(1.1875);
+    expect(out.x).toBeCloseTo(1 - 0.09375);
+    expect(out.margin).toEqual([6.75, 6.75, 3, 3]);
+  });
+
   it('shifts x to keep centered and right-aligned text anchored', () => {
     expect(withTextWidthSlack(box(), 'center').x).toBeCloseTo(1 - 0.03);
     expect(withTextWidthSlack(box(), 'right').x).toBeCloseTo(1 - 0.06);

--- a/src/__tests__/text-whitespace.test.js
+++ b/src/__tests__/text-whitespace.test.js
@@ -100,12 +100,15 @@ describe('withTextWidthSlack', () => {
     }
   });
 
-  it('widens a left-anchored box without moving x, for no-wrap and wrapping text alike', () => {
-    for (const opts of [box(), box({ wrap: true })]) {
-      const out = withTextWidthSlack(opts);
-      expect(out.w).toBeCloseTo(1.06);
-      expect(out.x).toBe(1);
-    }
+  it('keeps wrapping text inside its browser-measured box', () => {
+    const opts = box({ wrap: true });
+    expect(withTextWidthSlack(opts)).toBe(opts);
+  });
+
+  it('widens a left-anchored no-wrap box without moving x', () => {
+    const out = withTextWidthSlack(box());
+    expect(out.w).toBeCloseTo(1.06);
+    expect(out.x).toBe(1);
   });
 
   it('applies a 0.02in floor for tiny boxes', () => {

--- a/src/__tests__/text-whitespace.test.js
+++ b/src/__tests__/text-whitespace.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { splitPreformattedText } from '../utils.js';
+import { splitPreformattedText, textWraps, withTextWidthSlack, withNoWrapInsetSlack } from '../utils.js';
 
 const texts = (segs) => segs.map((s) => s.text);
 const breaks = (segs) => segs.map((s) => s.breakLine);
@@ -75,5 +75,79 @@ describe('splitPreformattedText', () => {
   it('returns nothing for empty / terminator-only content', () => {
     expect(splitPreformattedText('\n', 'pre', { isLastChild: true })).toEqual([]);
     expect(splitPreformattedText('', 'pre', { isLastChild: true })).toEqual([]);
+  });
+});
+
+describe('textWraps', () => {
+  it('is false for nowrap and pre (single measured line, wrap="none", no spAutoFit)', () => {
+    expect(textWraps({ whiteSpace: 'nowrap' })).toBe(false);
+    expect(textWraps({ whiteSpace: 'pre' })).toBe(false);
+  });
+
+  it('is true for wrapping white-space modes', () => {
+    expect(textWraps({ whiteSpace: 'normal' })).toBe(true);
+    expect(textWraps({ whiteSpace: 'pre-wrap' })).toBe(true);
+    expect(textWraps({ whiteSpace: 'pre-line' })).toBe(true);
+  });
+});
+
+describe('withTextWidthSlack', () => {
+  const box = (over = {}) => ({ x: 1, y: 1, w: 1, h: 0.2, wrap: false, ...over });
+
+  it('leaves vertical, rotated, and zero-width boxes untouched', () => {
+    for (const opts of [box({ vert: 'eaVert' }), box({ rotate: 90 }), box({ w: 0 })]) {
+      expect(withTextWidthSlack(opts)).toBe(opts);
+    }
+  });
+
+  it('widens a left-anchored box without moving x, for no-wrap and wrapping text alike', () => {
+    for (const opts of [box(), box({ wrap: true })]) {
+      const out = withTextWidthSlack(opts);
+      expect(out.w).toBeCloseTo(1.06);
+      expect(out.x).toBe(1);
+    }
+  });
+
+  it('applies a 0.02in floor for tiny boxes', () => {
+    const out = withTextWidthSlack(box({ w: 0.1 }));
+    expect(out.w).toBeCloseTo(0.12);
+  });
+
+  it('shifts x to keep centered and right-aligned text anchored', () => {
+    expect(withTextWidthSlack(box(), 'center').x).toBeCloseTo(1 - 0.03);
+    expect(withTextWidthSlack(box(), 'right').x).toBeCloseTo(1 - 0.06);
+  });
+});
+
+describe('withNoWrapInsetSlack', () => {
+  // margin follows the PptxGenJS inset order [lIns, rIns, bIns, tIns], in points
+  const box = (over = {}) => ({ x: 1, y: 1, w: 1, h: 0.2, wrap: false, margin: [6, 6, 6, 6], ...over });
+
+  it('leaves wrapping, vertical, zero-width, and non-array-margin boxes untouched', () => {
+    for (const opts of [box({ wrap: true }), box({ vert: 'eaVert' }), box({ w: 0 }), box({ margin: 0 })]) {
+      expect(withNoWrapInsetSlack(opts)).toBe(opts);
+    }
+  });
+
+  // margin index order follows PptxGenJS insets: [lIns, rIns, bIns, tIns]
+  it('keeps the box geometry and takes slack from the right inset for left-aligned text', () => {
+    const out = withNoWrapInsetSlack(box(), 'left');
+    expect(out.w).toBe(1);
+    expect(out.x).toBe(1);
+    expect(out.margin).toEqual([6, 6 - 0.06 * 72, 6, 6]);
+  });
+
+  it('splits the slack across both horizontal insets for centered text', () => {
+    const out = withNoWrapInsetSlack(box(), 'center');
+    expect(out.margin[0]).toBeCloseTo(6 - (0.06 * 72) / 2);
+    expect(out.margin[1]).toBeCloseTo(6 - (0.06 * 72) / 2);
+    expect(out.margin[2]).toBe(6);
+    expect(out.margin[3]).toBe(6);
+  });
+
+  it('takes slack from the left inset for right-aligned text and floors insets at 0', () => {
+    const out = withNoWrapInsetSlack(box({ margin: [1, 6, 6, 6] }), 'right');
+    expect(out.margin[0]).toBe(0);
+    expect(out.margin[1]).toBe(6);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1190,9 +1190,10 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
           // boxes get no autofit at all: their single line never needs fitting.
           // Known limitation: a bare <a:normAutofit/> carries no fontScale, and
           // desktop PowerPoint only computes one when the shape is next edited
-          // (https://github.com/gitbrent/PptxGenJS/issues/544) - so there the
-          // shrink is a backstop; withTextWidthSlack is the primary defense
-          // because it prevents the re-wrap from adding a line at all.
+          // (https://github.com/gitbrent/PptxGenJS/issues/544). Wrapping boxes
+          // still retain their measured width so they cannot cross an authored
+          // boundary; withTextWidthSlack remains the primary defense for no-wrap
+          // labels because it prevents a renderer from adding a line at all.
           options: withTextWidthSlack({
             x,
             y,

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,9 @@ import {
   getBorderInfo,
   generateCompositeBorderSVG,
   isClippedByParent,
+  textWraps,
+  withTextWidthSlack,
+  withNoWrapInsetSlack,
   generateCustomShapeSVG,
   getUsedFontFamilies,
   getAutoDetectedFonts,
@@ -1179,15 +1182,26 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
           // Honor CSS white-space: a `nowrap`/`pre` element must not re-wrap in
           // the exported slide (otherwise a single line measured in the browser
           // can wrap in PowerPoint/LibreOffice due to font-metric differences).
-          options: {
+          // Autofit: wrapping boxes get 'shrink' (<a:normAutofit/>) - a renderer
+          // whose wider glyph metrics re-wrap the text into an extra line shrinks
+          // it to fit instead of spilling over content below the box (spAutoFit
+          // grows the box, which Google Slides turns into visible overflow, and
+          // LibreOffice's spAutoFit re-layout even ignores wrap="none"). No-wrap
+          // boxes get no autofit at all: their single line never needs fitting.
+          // Known limitation: a bare <a:normAutofit/> carries no fontScale, and
+          // desktop PowerPoint only computes one when the shape is next edited
+          // (https://github.com/gitbrent/PptxGenJS/issues/544) - so there the
+          // shrink is a backstop; withTextWidthSlack is the primary defense
+          // because it prevents the re-wrap from adding a line at all.
+          options: withTextWidthSlack({
             x,
             y,
             w: unrotatedW,
             h: unrotatedH,
             margin: 0,
-            autoFit: true,
-            wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
-          },
+            fit: textWraps(style) ? 'shrink' : 'none',
+            wrap: textWraps(style),
+          }),
         },
       ],
       stopRecursion: false,
@@ -1326,12 +1340,12 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
     const ulPaddingBottom = parseFloat(style.paddingBottom) || 0;
     const ulPaddingLeft = parseFloat(style.paddingLeft) || 0;
 
-    // Convert to inches for PPTX margin array: [top, right, bottom, left]
+    // PptxGenJS consumes the margin array as [lIns, rIns, bIns, tIns], in points
     const listMargin = [
-      ulPaddingTop * PX_TO_INCH * config.scale * 72,
+      ulPaddingLeft * PX_TO_INCH * config.scale * 72,
       ulPaddingRight * PX_TO_INCH * config.scale * 72,
       ulPaddingBottom * PX_TO_INCH * config.scale * 72,
-      ulPaddingLeft * PX_TO_INCH * config.scale * 72,
+      ulPaddingTop * PX_TO_INCH * config.scale * 72,
     ];
 
     liChildren.forEach((child, index) => {
@@ -1518,20 +1532,23 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
         zIndex: parentSortKey.concat([0, -1]),
         domOrder,
         textParts: listItems,
-        options: {
-          x,
-          y,
-          w,
-          h,
-          align: 'left',
-          valign: 'top',
-          // Apply CSS padding as PPTX text box inset margin [top, right, bottom, left] in points
-          margin: listMargin,
-          autoFit: true,
-          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
-          vert: writingModeVert,
-          ...(writingModeVert && { textDirection: mapVertToTextDirection(writingModeVert) }),
-        },
+        options: withTextWidthSlack(
+          {
+            x,
+            y,
+            w,
+            h,
+            align: 'left',
+            valign: 'top',
+            // CSS padding applied as PPTX text box insets in points
+            margin: listMargin,
+            fit: textWraps(style) ? 'shrink' : 'none',
+            wrap: textWraps(style),
+            vert: writingModeVert,
+            ...(writingModeVert && { textDirection: mapVertToTextDirection(writingModeVert) }),
+          },
+          'left',
+        ),
       });
 
       return { items, stopRecursion: true };
@@ -1770,11 +1787,12 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
       }
 
       const padding = getPadding(style, config.scale);
+      // PptxGenJS consumes the margin array as [lIns, rIns, bIns, tIns]
       const margin = [
-        padding[3] * 72, // top
+        padding[3] * 72, // left
         padding[1] * 72, // right
         padding[2] * 72, // bottom
-        padding[0] * 72, // left
+        padding[0] * 72, // top
       ];
 
       textPayload = { text: textParts, align, valign, margin };
@@ -1858,20 +1876,23 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
         zIndex: parentSortKey.concat([0, -1]),
         domOrder,
         textParts: textPayload.text,
-        options: {
-          x,
-          y,
-          w,
-          h,
-          align: textPayload.align,
-          valign: textPayload.valign,
-          rotate: rotation,
-          margin: textPayload.margin,
-          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
-          autoFit: true,
-          vert: writingModeVert,
-          ...(writingModeVert && { textDirection: mapVertToTextDirection(writingModeVert) }),
-        },
+        options: withTextWidthSlack(
+          {
+            x,
+            y,
+            w,
+            h,
+            align: textPayload.align,
+            valign: textPayload.valign,
+            rotate: rotation,
+            margin: textPayload.margin,
+            wrap: textWraps(style),
+            fit: textWraps(style) ? 'shrink' : 'none',
+            vert: writingModeVert,
+            ...(writingModeVert && { textDirection: mapVertToTextDirection(writingModeVert) }),
+          },
+          textPayload.align,
+        ),
       });
     }
     if (hasCompositeBorder) {
@@ -1954,17 +1975,35 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
       }
 
       if (textPayload) {
+        // A box with a visible fill, border, or shadow must keep its measured size - widening it
+        // would stretch the visible shape - so no-wrap text is split out of it: the shape is
+        // emitted at its exact measured size and the text goes in a separate invisible box that
+        // can safely take width slack. Keeping the text inside the shape is not enough for
+        // renderers with no no-wrap concept (Google Slides): they wrap at width minus insets,
+        // and shrink a round-rect's text area by its corner radius on top of that.
+        const isVisibleShape = Boolean(useSolidFill || hasUniformBorder || hasShadow);
+        const splitNoWrapText = isVisibleShape && !textWraps(style) && !rotation && !writingModeVert;
+        if (splitNoWrapText) {
+          items.push({
+            type: 'shape',
+            zIndex: parentSortKey.concat([-Infinity]),
+            domOrder,
+            shapeType,
+            options: shapeOpts,
+          });
+        }
         const textOptions = {
-          shape: shapeType,
-          ...shapeOpts,
+          ...(splitNoWrapText ? {} : { shape: shapeType, ...shapeOpts }),
+          x,
+          y,
           w,
           h,
           rotate: rotation,
           align: textPayload.align,
           valign: textPayload.valign,
           margin: textPayload.margin,
-          wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
-          autoFit: true,
+          wrap: textWraps(style),
+          fit: textWraps(style) ? 'shrink' : 'none',
           vert: writingModeVert,
           ...(writingModeVert && { textDirection: mapVertToTextDirection(writingModeVert) }),
         };
@@ -1973,7 +2012,11 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
           zIndex: parentSortKey.concat([0, -1]),
           domOrder,
           textParts: textPayload.text,
-          options: textOptions,
+          options: splitNoWrapText
+            ? withTextWidthSlack(textOptions, textPayload.align)
+            : isVisibleShape
+              ? withNoWrapInsetSlack(textOptions, textPayload.align)
+              : withTextWidthSlack(textOptions, textPayload.align),
         });
       } else if (!hasPartialBorderRadius || customShapeName) {
         items.push({

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,6 +153,53 @@ export function extractTableData(node, scale) {
   return { rows, colWidths };
 }
 
+// Whether text in this element may re-wrap in the exported slide. `nowrap`/`pre` boxes must keep
+// their single browser-measured line, so they get wrap="none" and no <a:spAutoFit/> (LibreOffice's
+// autofit re-layout ignores wrap="none" and wraps inside the measured box).
+export function textWraps(style) {
+  return !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre');
+}
+
+// Text boxes are sized to the exact pixel measured in the browser, so any renderer whose font
+// metrics run slightly wider than Chromium's re-breaks the lines: Google Slides has no "don't
+// wrap" text property at all (imported text always wraps at the shape width), and a re-wrapped
+// paragraph gains a line and spills below its box. Give bare text boxes horizontal slack -
+// no-wrap lines keep their single line, wrapping paragraphs keep the browser's line count -
+// shifting x so the rendered text keeps its visual anchor. Callers must not apply this to
+// filled/bordered shapes: widening those stretches the visible shape (their no-wrap slack is
+// carved out of the text insets instead, see withNoWrapInsetSlack). Rotated and
+// vertical-writing boxes are left untouched: their pivot would move with the width.
+export function withTextWidthSlack(options, align) {
+  if (options.vert || options.rotate || !(options.w > 0)) {
+    return options;
+  }
+  const slack = Math.max(options.w * 0.06, 0.02);
+  const x = align === 'right' ? options.x - slack : align === 'center' ? options.x - slack / 2 : options.x;
+  return { ...options, x, w: options.w + slack };
+}
+
+// Counterpart of withNoWrapSlack for visible shapes (fill/border/shadow), which must keep their
+// measured size: the slack is carved out of the horizontal text insets instead. Renderers with no
+// no-wrap concept (Google Slides) wrap at shape width minus insets, and CSS padding is exported
+// as exactly-measured insets - leaving zero room for metric drift inside e.g. a badge pill.
+// margin is the PptxGenJS inset array in points, mapped as [lIns, rIns, bIns, tIns].
+export function withNoWrapInsetSlack(options, align) {
+  if (options.wrap !== false || options.vert || !(options.w > 0) || !Array.isArray(options.margin)) {
+    return options;
+  }
+  const slackPt = Math.max(options.w * 0.06, 0.02) * 72;
+  const margin = [...options.margin];
+  if (align === 'center') {
+    margin[0] = Math.max(0, margin[0] - slackPt / 2);
+    margin[1] = Math.max(0, margin[1] - slackPt / 2);
+  } else if (align === 'right') {
+    margin[0] = Math.max(0, margin[0] - slackPt);
+  } else {
+    margin[1] = Math.max(0, margin[1] - slackPt);
+  }
+  return { ...options, margin };
+}
+
 // Checks if any parent element has overflow: hidden which would clip this element
 export function isClippedByParent(node) {
   let parent = node.parentElement;

--- a/src/utils.js
+++ b/src/utils.js
@@ -161,16 +161,15 @@ export function textWraps(style) {
 }
 
 // Text boxes are sized to the exact pixel measured in the browser, so any renderer whose font
-// metrics run slightly wider than Chromium's re-breaks the lines: Google Slides has no "don't
-// wrap" text property at all (imported text always wraps at the shape width), and a re-wrapped
-// paragraph gains a line and spills below its box. Give bare text boxes horizontal slack -
-// no-wrap lines keep their single line, wrapping paragraphs keep the browser's line count -
-// shifting x so the rendered text keeps its visual anchor. Callers must not apply this to
-// filled/bordered shapes: widening those stretches the visible shape (their no-wrap slack is
-// carved out of the text insets instead, see withNoWrapInsetSlack). Rotated and
+// metrics run slightly wider than Chromium's can re-break a no-wrap label. Google Slides has no
+// "don't wrap" text property at all, so give bare no-wrap text boxes horizontal slack and shift x
+// to keep the rendered text visually anchored. Wrapping text must stay inside its browser-measured
+// rectangle: widening it can consume an authored inset or cross its containing boundary. Callers
+// must not apply this to filled/bordered shapes: widening those stretches the visible shape (their
+// no-wrap slack is carved out of the text insets instead, see withNoWrapInsetSlack). Rotated and
 // vertical-writing boxes are left untouched: their pivot would move with the width.
 export function withTextWidthSlack(options, align) {
-  if (options.vert || options.rotate || !(options.w > 0)) {
+  if (options.wrap !== false || options.vert || options.rotate || !(options.w > 0)) {
     return options;
   }
   const slack = Math.max(options.w * 0.06, 0.02);

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,7 +172,8 @@ export function withTextWidthSlack(options, align) {
   if (options.wrap !== false || options.vert || options.rotate || !(options.w > 0)) {
     return options;
   }
-  const slack = Math.max(options.w * 0.06, 0.02);
+  const horizontalInsets = Array.isArray(options.margin) ? (options.margin[0] + options.margin[1]) / 72 : 0;
+  const slack = Math.max(options.w * 0.06, 0.02, horizontalInsets);
   const x = align === 'right' ? options.x - slack : align === 'center' ? options.x - slack / 2 : options.x;
   return { ...options, x, w: options.w + slack };
 }
@@ -1395,7 +1396,9 @@ export async function getAutoDetectedFonts(usedFamilies) {
  * and so the classification is unit-testable.
  */
 export function classifyFontVariant(weight, style) {
-  const wRaw = String(weight || '400').toLowerCase().trim();
+  const wRaw = String(weight || '400')
+    .toLowerCase()
+    .trim();
   let w = parseInt(wRaw, 10);
   if (isNaN(w)) {
     if (wRaw === 'bold' || wRaw === 'bolder') w = 700;


### PR DESCRIPTION
## TL;DR

Ensures no-wrap text boxes reserve at least enough spare width to cover their horizontal insets, preventing imported labels and pills from re-wrapping in Google Slides.

## Why

Google Slides wraps imported text at the shape width minus its insets even when the authored text is marked no-wrap. Exact-fit boxes therefore lose usable width to preserved CSS padding.

## What

Widens only no-wrap bare text boxes and invisible text companions while retaining text alignment, visible-pill geometry, authored insets, and wrapping-paragraph containment.
