### PR TITLE
fix: list text insets are exported in the wrong order (top and left swapped)

### DIFF
--- a/src/__tests__/list-text-insets.test.js
+++ b/src/__tests__/list-text-insets.test.js
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { exportToPptx } from '../index.js';
+
+// A 1920px-wide root is exported as a 10in slide, so 1 CSS px is 914400 / 96 / 2 EMU,
+// and 1 CSS px of padding is 0.75 / 2 pt.
+const EMU_PER_PT = 12700;
+const PT_PER_PX = 0.75 * 0.5;
+
+function rect({ left, top, width, height }) {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON() {
+      return this;
+    },
+  };
+}
+
+beforeAll(() => {
+  let fillStyle = '';
+  HTMLCanvasElement.prototype.getContext = () => ({
+    get fillStyle() {
+      return fillStyle;
+    },
+    set fillStyle(value) {
+      fillStyle = value;
+    },
+    clearRect: () => {},
+    fillRect: () => {},
+    getImageData: () => ({ data: [0, 0, 0, 255] }),
+  });
+});
+
+describe('list text insets', () => {
+  it('maps each CSS padding edge of a <ul> to the matching PPTX inset', async () => {
+    // Four distinct paddings, so a swapped pair cannot go unnoticed.
+    const paddingPx = { top: 12, right: 4, bottom: 8, left: 20 };
+
+    const slide = document.createElement('div');
+    slide.setAttribute('style', 'position:relative;width:1920px;height:1080px;background:#fff');
+
+    const list = document.createElement('ul');
+    list.setAttribute(
+      'style',
+      'position:absolute;left:200px;top:200px;width:400px;height:120px;color:#111;font-size:16px;' +
+        `line-height:25px;margin:0;padding:${paddingPx.top}px ${paddingPx.right}px ${paddingPx.bottom}px ${paddingPx.left}px`
+    );
+    for (const text of ['First item', 'Second item']) {
+      const item = document.createElement('li');
+      item.setAttribute('style', 'font-size:16px;line-height:25px');
+      item.textContent = text;
+      list.appendChild(item);
+    }
+
+    slide.appendChild(list);
+    document.body.appendChild(slide);
+
+    slide.getBoundingClientRect = () => rect({ left: 0, top: 0, width: 1920, height: 1080 });
+    list.getBoundingClientRect = () => rect({ left: 200, top: 200, width: 400, height: 120 });
+    Array.from(list.children).forEach((item, index) => {
+      item.getBoundingClientRect = () => rect({ left: 220, top: 212 + index * 25, width: 376, height: 25 });
+    });
+
+    try {
+      const blob = await exportToPptx(slide, { skipDownload: true, autoEmbedFonts: false });
+      const zip = await JSZip.loadAsync(blob);
+      const xml = await zip.file('ppt/slides/slide1.xml').async('string');
+
+      const doc = new DOMParser().parseFromString(xml, 'text/xml');
+      const listShape = Array.from(doc.getElementsByTagName('p:sp')).find((shape) =>
+        Array.from(shape.getElementsByTagName('a:t')).some((run) => run.textContent.includes('First item'))
+      );
+      expect(listShape).toBeDefined();
+
+      const bodyPr = listShape.getElementsByTagName('a:bodyPr')[0];
+      const insetEmu = (px) => Math.round(px * PT_PER_PX * EMU_PER_PT);
+
+      expect(Number(bodyPr.getAttribute('lIns'))).toBe(insetEmu(paddingPx.left));
+      expect(Number(bodyPr.getAttribute('rIns'))).toBe(insetEmu(paddingPx.right));
+      expect(Number(bodyPr.getAttribute('bIns'))).toBe(insetEmu(paddingPx.bottom));
+      expect(Number(bodyPr.getAttribute('tIns'))).toBe(insetEmu(paddingPx.top));
+    } finally {
+      slide.remove();
+    }
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1326,12 +1326,12 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
     const ulPaddingBottom = parseFloat(style.paddingBottom) || 0;
     const ulPaddingLeft = parseFloat(style.paddingLeft) || 0;
 
-    // Convert to inches for PPTX margin array: [top, right, bottom, left]
+    // PptxGenJS consumes the margin array as [lIns, rIns, bIns, tIns], in points
     const listMargin = [
-      ulPaddingTop * PX_TO_INCH * config.scale * 72,
+      ulPaddingLeft * PX_TO_INCH * config.scale * 72,
       ulPaddingRight * PX_TO_INCH * config.scale * 72,
       ulPaddingBottom * PX_TO_INCH * config.scale * 72,
-      ulPaddingLeft * PX_TO_INCH * config.scale * 72,
+      ulPaddingTop * PX_TO_INCH * config.scale * 72,
     ];
 
     liChildren.forEach((child, index) => {
@@ -1525,7 +1525,7 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
           h,
           align: 'left',
           valign: 'top',
-          // Apply CSS padding as PPTX text box inset margin [top, right, bottom, left] in points
+          // CSS padding applied as PPTX text box insets, in points
           margin: listMargin,
           autoFit: true,
           wrap: !(style.whiteSpace === 'nowrap' || style.whiteSpace === 'pre'),
@@ -1770,11 +1770,13 @@ function prepareRenderItem(node, config, domOrder, pptx, effectiveZIndex, comput
       }
 
       const padding = getPadding(style, config.scale);
+      // getPadding returns [top, right, bottom, left]; PptxGenJS consumes the margin
+      // array as [lIns, rIns, bIns, tIns], in points
       const margin = [
-        padding[3] * 72, // top
+        padding[3] * 72, // left
         padding[1] * 72, // right
         padding[2] * 72, // bottom
-        padding[0] * 72, // left
+        padding[0] * 72, // top
       ];
 
       textPayload = { text: textParts, align, valign, margin };


### PR DESCRIPTION
## TL;DR

A `<ul>`'s **top** padding is exported as its **left** text inset, and its left padding as its top
inset. One-line-per-element fix in the list margin array, plus a regression test.

## Why

PptxGenJS consumes a text box's `margin` array as `[lIns, rIns, bIns, tIns]` - left, right,
bottom, **top**:

```js
// pptxgenjs/dist/pptxgen.cjs.js, addTextDefinition
if (Array.isArray(opts.margin)) {
    opts.margin.forEach((val, idx) => { ... });   // 0 -> lIns, 1 -> rIns, 2 -> bIns, 3 -> tIns
}
```

The list path in `src/index.js` builds it in CSS shorthand order instead:

```js
const listMargin = [
  ulPaddingTop * PX_TO_INCH * config.scale * 72,     // -> lIns
  ulPaddingRight * ...,                              // -> rIns  (correct by coincidence)
  ulPaddingBottom * ...,                             // -> bIns  (correct by coincidence)
  ulPaddingLeft * PX_TO_INCH * config.scale * 72,    // -> tIns
];
```

Right and bottom happen to land in the right slots; top and left swap. So a list styled
`padding: 12px 4px 8px 20px` exports with the 12px top padding as its left inset and the 20px left
padding as its top inset: the bullets lose their indent and the whole list is pushed down instead.
Asymmetric vertical/horizontal padding, which is the common case for lists, is where it shows.

The generic (non-list) text path a few hundred lines below already builds the array correctly -
`[padding[3], padding[1], padding[2], padding[0]]` - only its inline comments were labelled
`top / right / bottom / left`. Those labels are corrected here too; no values change on that path.

### Before / after

`<ul style="padding: 12px 4px 8px 20px">` at export scale 0.5, read off `ppt/slides/slide1.xml`:

```xml
<!-- before: 12px top padding became lIns, 20px left padding became tIns -->
<a:bodyPr wrap="square" lIns="57150" tIns="95250" rIns="19050" bIns="38100"/>

<!-- after: each CSS edge lands in its own inset -->
<a:bodyPr wrap="square" lIns="95250" tIns="57150" rIns="19050" bIns="38100"/>
```

12px -> 57150 EMU and 20px -> 95250 EMU at that scale, so the two values are simply exchanged.

## What

- `src/index.js`: `listMargin` now passes `[left, right, bottom, top]`, and the two comments
  describing the inset order say what PptxGenJS actually consumes.
- `src/__tests__/list-text-insets.test.js`: exports a `<ul>` with four distinct paddings and asserts
  each CSS edge against its own `bodyPr` inset, so a future swap of any pair fails. Follows the
  existing JSZip round-trip style used in `animations.test.js` and `pptx-normalizer.test.js`.

The test fails on `master` with `expected 57150 to be 95250` and passes with the fix. `npx vitest
run` is green (98 passed, 1 skipped), and `npx eslint .` reports the same 25 problems as `master`,
so nothing new.
