### PR TITLE
fix: resolve @font-face relative URLs against the stylesheet href

### DIFF
--- a/src/__tests__/font-detection.test.js
+++ b/src/__tests__/font-detection.test.js
@@ -67,6 +67,32 @@ describe('getFontsFromStyleSheets', () => {
     expect(found[0].url).toBe('fonts/Inter-Regular.ttf');
   });
 
+  it('resolves relative src URLs against the stylesheet href, not the document base', () => {
+    // Fixture: an external stylesheet at /assets/deck.css declares
+    // src: url('fonts/Inter-Regular.ttf'). The browser resolves that URL
+    // relative to the stylesheet when rendering, but fetch() during embedding
+    // resolves it against the document — so without href-based resolution the
+    // font 404s and auto-embed silently falls back to a system font.
+    const sheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('fonts/Inter-Regular.ttf')", weight: '400' }),
+    ]);
+    sheet.href = 'https://example.com/assets/deck.css';
+
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [sheet]);
+    expect(found).toHaveLength(1);
+    expect(found[0].url).toBe('https://example.com/assets/fonts/Inter-Regular.ttf');
+  });
+
+  it('leaves relative src URLs untouched for hrefless (inline <style>) sheets', () => {
+    const sheet = makeSheet([
+      fontFaceRule({ family: 'Inter', src: "url('fonts/Inter-Regular.ttf')", weight: '400' }),
+    ]);
+
+    const found = getFontsFromStyleSheets(new Set(['Inter']), [sheet]);
+    expect(found).toHaveLength(1);
+    expect(found[0].url).toBe('fonts/Inter-Regular.ttf');
+  });
+
   it('recurses into @import chains — the common `theme.css imports fonts.css` pattern', () => {
     // Fixture: `fonts.css` (imported) declares @font-face for Inter Regular + Bold.
     // `theme.css` (top-level) contains only an @import pointing at fonts.css.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1189,7 +1189,7 @@ export function extractSpeakerNotesFromElement(root) {
  * Parses @font-face declarations from raw CSS text string.
  * Used as a fallback when document.styleSheets[i].cssRules is blocked by CORS.
  */
-export function parseFontFacesFromCssText(cssText, usedFamilies) {
+export function parseFontFacesFromCssText(cssText, usedFamilies, baseHref) {
   const foundFonts = [];
   const processedUrls = new Set();
 
@@ -1217,7 +1217,16 @@ export function parseFontFacesFromCssText(cssText, usedFamilies) {
     const srcMatch = /src\s*:\s*([^;]+)/i.exec(block);
     if (!srcMatch) continue;
 
-    const url = extractFontUrl(srcMatch[1]);
+    let url = extractFontUrl(srcMatch[1]);
+    // Relative URLs in fetched CSS text are relative to the stylesheet href,
+    // not the document; resolve them when the caller provides the base.
+    if (url && baseHref) {
+      try {
+        url = new URL(url, baseHref).href;
+      } catch (e) {
+        // keep original url if it cannot be resolved
+      }
+    }
     if (url && !processedUrls.has(url)) {
       processedUrls.add(url);
       const weightMatch = /font-weight\s*:\s*([^;]+)/i.exec(block);
@@ -1269,7 +1278,25 @@ export function getFontsFromStyleSheets(usedFamilies, styleSheets, blockedHrefs 
         if (!usedFamilies.has(familyName)) continue;
 
         const src = rule.style.getPropertyValue('src');
-        const url = extractFontUrl(src);
+        let url = extractFontUrl(src);
+
+        // Browsers return @font-face src URLs exactly as written in the CSS.
+        // For external stylesheets (e.g. assets/deck.css declaring
+        // src: url('fonts/x.woff2')) those URLs are relative to the
+        // stylesheet, but a later fetch() resolves them against the document
+        // base — a silent embed failure and system-font fallback. Resolve
+        // against the owning stylesheet's href when it has one; hrefless
+        // (inline <style>) sheets already resolve correctly at fetch time.
+        if (url) {
+          const base = (rule.parentStyleSheet && rule.parentStyleSheet.href) || sheet.href;
+          if (base) {
+            try {
+              url = new URL(url, base).href;
+            } catch (e) {
+              // keep original url if it cannot be resolved
+            }
+          }
+        }
 
         if (url && !processedUrls.has(url)) {
           processedUrls.add(url);
@@ -1316,7 +1343,7 @@ export async function getAutoDetectedFonts(usedFamilies) {
         const res = await fetch(href);
         if (!res.ok) return [];
         const cssText = await res.text();
-        return parseFontFacesFromCssText(cssText, usedFamilies);
+        return parseFontFacesFromCssText(cssText, usedFamilies, href);
       } catch (e) {
         console.warn('Failed to fetch cross-origin stylesheet fallback for fonts:', href, e);
         return [];


### PR DESCRIPTION
## Problem

When `@font-face` rules live in an **external stylesheet** with relative `src` URLs, auto font embedding silently fails and PowerPoint falls back to a system font (Arial).

```
deck.html
assets/deck.css      ← @font-face { src: url('fonts/Pretendard-Regular.woff2') }
assets/fonts/Pretendard-Regular.woff2
```

The browser resolves `fonts/Pretendard-Regular.woff2` relative to the stylesheet (`assets/fonts/…`), so the page renders correctly. But `getFontsFromStyleSheets` returns the URL exactly as written in the CSS, and the embedder's later `fetch()` resolves it against the **document** base (`fonts/…`) → 404 → `Failed to embed font family` warning → system-font fallback. In the headless exporter CLI the page console warning is never surfaced, so the failure is fully silent: a 15 KB PPTX with no fonts embedded looks identical to a successful export at a glance.

Reproduced with dom-to-pptx 2.1.1 on Windows (headless exporter, local `file://` deck with fonts declared in an external CSS file).

## Fix

Resolve extracted font URLs against the owning stylesheet's `href` (`rule.parentStyleSheet.href` → `sheet.href`) in:

- the `cssRules` walk in `getFontsFromStyleSheets`
- the fetched-CSS-text CORS fallback (`parseFontFacesFromCssText` gains an optional `baseHref` param, passed from the fetch fallback)

Hrefless sheets (inline `<style>`) are deliberately left untouched: their relative URLs already resolve correctly against the document at fetch time, and resolving them against `document.baseURI` would change existing behavior.

## Tests

- New: resolves relative `src` URLs against the stylesheet href
- New: leaves relative `src` URLs untouched for hrefless sheets
- Full suite passes (99 passed, 1 pre-existing skip)

After this fix, our real-world deck (external CSS + 5 Pretendard woff2 weights) goes from 14 KB/no fonts to a correctly embedded export that opens in desktop PowerPoint with fonts intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)